### PR TITLE
feat: shared storage layer and diary ui

### DIFF
--- a/DiaryPlus.html
+++ b/DiaryPlus.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Diary Plus</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+  </head>
+  <body>
+    <div data-include="nav"></div>
+    <main>
+      <div class="container">
+        <header>
+          <h1>Diary</h1>
+          <p>Track hydration, sleep, movement, and mood with unified storage.</p>
+        </header>
+
+        <section class="card-grid" id="summary-cards"></section>
+
+        <section>
+          <form id="event-form">
+            <h2>Add event</h2>
+            <div class="form-row">
+              <label>
+                Type
+                <select name="type" required>
+                  <option value="water">Water (ml)</option>
+                  <option value="caffeine">Caffeine (mg)</option>
+                  <option value="steps">Steps</option>
+                  <option value="sleep">Sleep (min)</option>
+                  <option value="stress">Stress (1-10)</option>
+                  <option value="energy">Energy (1-10)</option>
+                  <option value="srv">SRV (1-10)</option>
+                  <option value="med">Medication</option>
+                </select>
+              </label>
+              <label>
+                Value
+                <input type="number" name="value" step="0.1" placeholder="e.g. 250" />
+              </label>
+              <label>
+                Note
+                <input type="text" name="note" placeholder="Optional notes" />
+              </label>
+            </div>
+            <div class="form-row">
+              <button type="submit">Add event</button>
+              <div style="display:flex; gap:0.5rem; align-items:center;">
+                <button type="button" class="secondary" id="export-btn">Export JSON</button>
+                <button type="button" class="secondary" id="import-btn">Import JSON</button>
+                <input type="file" id="import-file" accept="application/json" style="display:none" />
+              </div>
+            </div>
+          </form>
+        </section>
+
+        <section class="table-wrapper">
+          <table id="events-table">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Value</th>
+                <th>Note</th>
+                <th>Created</th>
+                <th>Updated</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </section>
+      </div>
+    </main>
+
+    <div class="toast" id="toast"></div>
+
+    <script src="./shared/storage.js"></script>
+    <script src="./shared/nav-loader.js"></script>
+    <script>
+      (function () {
+        const form = document.getElementById('event-form');
+        const tableBody = document.querySelector('#events-table tbody');
+        const cardsContainer = document.getElementById('summary-cards');
+        const toast = document.getElementById('toast');
+        const fileInput = document.getElementById('import-file');
+        const importBtn = document.getElementById('import-btn');
+        const exportBtn = document.getElementById('export-btn');
+
+        let events = [];
+
+        function createId() {
+          if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+            return crypto.randomUUID();
+          }
+          return 'evt_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+        }
+
+        function showToast(message) {
+          toast.textContent = message;
+          toast.classList.add('visible');
+          setTimeout(() => toast.classList.remove('visible'), 2200);
+        }
+
+        function renderCards() {
+          const now = new Date();
+          const day = StorageAPI.aggregates('day', now);
+          const week = StorageAPI.aggregates('week', now);
+          const month = StorageAPI.aggregates('month', now);
+          cardsContainer.innerHTML = [
+            cardMarkup('Water today', `${day.water_ml} ml`),
+            cardMarkup('Steps today', `${day.steps}`),
+            cardMarkup('Sleep this week', `${Math.round(week.sleep_min / 60)} h`),
+            cardMarkup('Meds this month', `${month.meds_count}`),
+            cardMarkup('Avg stress today', `${day.stress_avg}`),
+          ].join('');
+        }
+
+        function cardMarkup(title, value) {
+          return `<article class="card"><h3>${title}</h3><strong>${value}</strong></article>`;
+        }
+
+        function renderTable() {
+          const visibleEvents = events.filter((event) => !event.deleted_at);
+          if (!visibleEvents.length) {
+            tableBody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding:1.5rem; color:#64748b;">No events yet</td></tr>`;
+            return;
+          }
+          tableBody.innerHTML = '';
+          visibleEvents.forEach((event) => {
+            const row = document.createElement('tr');
+            row.dataset.id = event.id;
+            row.innerHTML = `
+              <td>${event.type}</td>
+              <td><input type="number" step="0.1" value="${event.value_number ?? ''}" aria-label="${event.type} value" /></td>
+              <td><input type="text" value="${event.note ? escapeHtml(event.note) : ''}" aria-label="${event.type} note" /></td>
+              <td>${formatDate(event.created_at)}</td>
+              <td>${formatDate(event.updated_at)}</td>
+              <td style="text-align:right;"><button type="button" class="danger" data-action="delete">Delete</button></td>
+            `;
+            const [valueInput, noteInput] = row.querySelectorAll('input');
+            valueInput.addEventListener('change', () => updateValue(event.id, valueInput.value));
+            noteInput.addEventListener('change', () => updateNote(event.id, noteInput.value));
+            row.querySelector('[data-action="delete"]').addEventListener('click', () => softDelete(event.id));
+            tableBody.appendChild(row);
+          });
+        }
+
+        function escapeHtml(text) {
+          const div = document.createElement('div');
+          div.textContent = text;
+          return div.innerHTML;
+        }
+
+        function updateValue(id, value) {
+          const target = events.find((item) => item.id === id);
+          if (!target) return;
+          const numeric = value === '' ? null : Number(value);
+          target.value_number = Number.isFinite(numeric) ? numeric : null;
+          target.updated_at = new Date().toISOString();
+          events = StorageAPI.saveEvents(events);
+          renderCards();
+          renderTable();
+          showToast('Event updated');
+        }
+
+        function updateNote(id, note) {
+          const target = events.find((item) => item.id === id);
+          if (!target) return;
+          target.note = note;
+          target.updated_at = new Date().toISOString();
+          events = StorageAPI.saveEvents(events);
+          renderTable();
+          showToast('Note updated');
+        }
+
+        function softDelete(id) {
+          const target = events.find((item) => item.id === id);
+          if (!target) return;
+          target.deleted_at = new Date().toISOString();
+          target.updated_at = target.deleted_at;
+          events = StorageAPI.saveEvents(events);
+          renderCards();
+          renderTable();
+          showToast('Event deleted');
+        }
+
+        function formatDate(value) {
+          const parsed = new Date(value);
+          if (Number.isNaN(parsed.getTime())) return '';
+          return parsed.toLocaleString();
+        }
+
+        function refresh() {
+          events = StorageAPI.loadEvents();
+          renderCards();
+          renderTable();
+        }
+
+        form.addEventListener('submit', (event) => {
+          event.preventDefault();
+          const formData = new FormData(form);
+          const type = formData.get('type');
+          const value = formData.get('value');
+          const note = formData.get('note');
+          const now = new Date().toISOString();
+          const numeric = value === '' ? null : Number(value);
+          const newEvent = {
+            id: createId(),
+            type,
+            note: note ? String(note) : '',
+            value_number: Number.isFinite(numeric) ? numeric : null,
+            created_at: now,
+            updated_at: now,
+          };
+          events.unshift(newEvent);
+          StorageAPI.saveEvents(events);
+          form.reset();
+          refresh();
+          showToast('Event added');
+        });
+
+        importBtn.addEventListener('click', () => fileInput.click());
+        fileInput.addEventListener('change', handleImportFile);
+        exportBtn.addEventListener('click', handleExport);
+
+        function handleExport() {
+          const data = StorageAPI.exportJson();
+          const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = `health-diary-${new Date().toISOString().slice(0, 10)}.json`;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+          URL.revokeObjectURL(url);
+          showToast('Export created');
+        }
+
+        async function handleImportFile(event) {
+          const file = event.target.files && event.target.files[0];
+          if (!file) return;
+          try {
+            const text = await file.text();
+            const payload = JSON.parse(text);
+            const { added, updated } = StorageAPI.importJson(payload);
+            events = StorageAPI.loadEvents();
+            renderCards();
+            renderTable();
+            showToast(`Импорт: +${added}, обновлено ${updated}`);
+          } catch (err) {
+            console.error('Import failed', err);
+            showToast('Import failed');
+          } finally {
+            event.target.value = '';
+          }
+        }
+
+        window.addEventListener('health:changed', () => {
+          events = StorageAPI.loadEvents();
+          renderCards();
+          renderTable();
+        });
+
+        refresh();
+      })();
+    </script>
+  </body>
+</html>

--- a/POCKET_README.txt
+++ b/POCKET_README.txt
@@ -1,0 +1,22 @@
+Pocket Health Links
+===================
+
+Offline usage
+-------------
+
+1. Open each HTML file in your browser once while you are online (`pocket_health_link.html`, `Summary.html`, `DiaryPlus.html`).
+2. Add them to your reading list or home screen; modern browsers will cache the assets for offline use.
+3. The app stores data in `localStorage`, so entries stay on the device even without connectivity.
+
+Backups
+-------
+
+- Use the **Export JSON** button on the diary page regularly. Save the file to cloud storage or email it to yourself.
+- To restore, pick **Import JSON** and choose the saved file. Existing entries merge by `id` and the latest `updated_at` timestamp wins.
+- Settings are merged as well, so older backups will not wipe newer configuration values.
+
+Tips
+----
+
+- Keep multiple backups in case a file becomes corrupted.
+- For cross-device transfer, export on one device and import on the other while both are online to move the JSON file.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
+# Health2099
+
+A lightweight offline-friendly health diary with shared storage. Use the Summary page for quick actions and the Diary for detailed editing, import/export, and historical view.
+
+## Manual smoke test
+
+1. Open `Summary.html` in a browser.
+2. Use the `+250 ml water` quick action.
+3. Open `DiaryPlus.html` (same tab or another tab) and confirm the new water event appears with updated totals.
+4. Edit the value in the diary table, verify Summary updates automatically (thanks to cross-tab sync).
+5. Export from the diary, then import the same file to validate merge behaviour.
+
+## Structure
+
+```
+shared/
+  storage.js       // LocalStorage wrapper (UMD + global)
+  nav-loader.js    // Injects the shared navigation
+  styles.css       // Shared styling
+includes/
+  nav.html         // Navigation partial
+DiaryPlus.html     // Diary UI
+Summary.html       // Summary / quick actions
+pocket_health_link.html // Landing with shortcuts
+scripts/smoke.md   // Manual QA checklist
+POCKET_README.txt  // Offline and backup guidance
+```
 

--- a/Summary.html
+++ b/Summary.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Summary</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+  </head>
+  <body>
+    <div data-include="nav"></div>
+    <main>
+      <div class="container">
+        <header>
+          <h1>Summary</h1>
+          <p>Overview of your recent health metrics with unified storage.</p>
+        </header>
+
+        <section class="card-grid" id="summary-cards"></section>
+
+        <section class="card-grid" id="averages"></section>
+
+        <section class="card">
+          <h2>Quick actions</h2>
+          <p>Log common events with one tap. Use the diary for detailed edits.</p>
+          <div style="display:flex; flex-wrap:wrap; gap:0.75rem;">
+            <button type="button" data-action="water" data-value="250">+250 ml water</button>
+            <button type="button" data-action="water" data-value="500">+500 ml water</button>
+            <button type="button" class="secondary" data-action="steps" data-value="1000">+1k steps</button>
+            <button type="button" class="secondary" data-action="sleep" data-value="480">+8h sleep</button>
+          </div>
+        </section>
+
+        <section class="table-wrapper">
+          <table id="recent-table">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Value</th>
+                <th>Note</th>
+                <th>Created</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </section>
+      </div>
+    </main>
+
+    <div class="toast" id="toast"></div>
+
+    <script src="./shared/storage.js"></script>
+    <script src="./shared/nav-loader.js"></script>
+    <script>
+      (function () {
+        const summaryCards = document.getElementById('summary-cards');
+        const averagesCards = document.getElementById('averages');
+        const tableBody = document.querySelector('#recent-table tbody');
+        const toast = document.getElementById('toast');
+        const quickButtons = document.querySelectorAll('[data-action]');
+
+        function showToast(message) {
+          toast.textContent = message;
+          toast.classList.add('visible');
+          setTimeout(() => toast.classList.remove('visible'), 2200);
+        }
+
+        function renderSummary() {
+          const now = new Date();
+          const day = StorageAPI.aggregates('day', now);
+          const week = StorageAPI.aggregates('week', now);
+          const month = StorageAPI.aggregates('month', now);
+          summaryCards.innerHTML = [
+            card('Water today', `${day.water_ml} ml`),
+            card('Steps today', `${day.steps}`),
+            card('Sleep this week', `${Math.round(week.sleep_min / 60)} h`),
+            card('Meds this month', `${month.meds_count}`),
+          ].join('');
+          averagesCards.innerHTML = [
+            card('Stress avg (day)', `${day.stress_avg}`),
+            card('Energy avg (day)', `${day.energy_avg}`),
+            card('SRV avg (day)', `${day.srv_avg}`),
+            card('Caffeine (week)', `${week.caffeine_mg} mg`),
+          ].join('');
+        }
+
+        function card(title, value) {
+          return `<article class="card"><h3>${title}</h3><strong>${value}</strong></article>`;
+        }
+
+        function renderRecent() {
+          const events = StorageAPI.loadEvents().filter((event) => !event.deleted_at).slice(0, 8);
+          if (!events.length) {
+            tableBody.innerHTML = `<tr><td colspan="4" style="text-align:center; padding:1.5rem; color:#64748b;">No events logged yet</td></tr>`;
+            return;
+          }
+          tableBody.innerHTML = '';
+          events.forEach((event) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+              <td>${event.type}</td>
+              <td>${event.value_number ?? ''}</td>
+              <td>${escapeHtml(event.note || '')}</td>
+              <td>${formatDate(event.created_at)}</td>
+            `;
+            tableBody.appendChild(row);
+          });
+        }
+
+        function escapeHtml(text) {
+          const div = document.createElement('div');
+          div.textContent = text;
+          return div.innerHTML;
+        }
+
+        function formatDate(value) {
+          const parsed = new Date(value);
+          if (Number.isNaN(parsed.getTime())) return '';
+          return parsed.toLocaleString();
+        }
+
+        quickButtons.forEach((button) => {
+          button.addEventListener('click', () => {
+            const action = button.dataset.action;
+            const value = Number(button.dataset.value || 0);
+            addQuickEvent(action, value);
+          });
+        });
+
+        function addQuickEvent(type, value) {
+          const now = new Date().toISOString();
+          const event = {
+            id: createId(),
+            type,
+            value_number: value || null,
+            note: '',
+            created_at: now,
+            updated_at: now,
+          };
+          const events = StorageAPI.loadEvents();
+          events.unshift(event);
+          StorageAPI.saveEvents(events);
+          renderSummary();
+          renderRecent();
+          showToast(`${type} logged`);
+        }
+
+        function createId() {
+          if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+            return crypto.randomUUID();
+          }
+          return 'evt_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+        }
+
+        function refresh() {
+          renderSummary();
+          renderRecent();
+        }
+
+        window.addEventListener('health:changed', refresh);
+
+        refresh();
+      })();
+    </script>
+  </body>
+</html>

--- a/includes/nav.html
+++ b/includes/nav.html
@@ -1,0 +1,7 @@
+<nav class="site-nav">
+  <a class="site-nav__brand" href="./pocket_health_link.html">Health2099</a>
+  <div class="site-nav__links">
+    <a href="./Summary.html">Summary</a>
+    <a href="./DiaryPlus.html">Diary</a>
+  </div>
+</nav>

--- a/pocket_health_link.html
+++ b/pocket_health_link.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Health2099 Pocket Links</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+    <style>
+      main { display: flex; align-items: center; justify-content: center; min-height: calc(100vh - 80px); }
+      .link-grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); width: 100%; max-width: 720px; }
+      .link-card { background: #fff; padding: 1.75rem; border-radius: 16px; box-shadow: 0 1px 4px rgba(15, 23, 42, 0.12); text-align: center; }
+      .link-card a { display: inline-block; margin-top: 1rem; }
+    </style>
+  </head>
+  <body>
+    <div data-include="nav"></div>
+    <main>
+      <div class="link-grid">
+        <article class="link-card">
+          <h1>Diary</h1>
+          <p>Log hydration, sleep, movement, and daily notes.</p>
+          <a href="./DiaryPlus.html" class="button">Open diary</a>
+        </article>
+        <article class="link-card">
+          <h1>Summary</h1>
+          <p>Check aggregated stats and quick actions.</p>
+          <a href="./Summary.html" class="button secondary">Open summary</a>
+        </article>
+      </div>
+    </main>
+    <script src="./shared/storage.js"></script>
+    <script src="./shared/nav-loader.js"></script>
+  </body>
+</html>

--- a/scripts/smoke.md
+++ b/scripts/smoke.md
@@ -1,0 +1,18 @@
+# Smoke checklist
+
+1. **Load pages**
+   - Open `pocket_health_link.html` and follow links to Summary and Diary pages.
+   - Confirm navigation bar renders with Summary + Diary entries.
+2. **Add + sync**
+   - On `Summary.html`, tap `+250 ml water` twice.
+   - Switch to `DiaryPlus.html` (same tab or a new one) and verify totals/cards reflect 500 ml water today.
+   - Edit the water entry value in the diary table; confirm the change appears back on Summary without reload.
+3. **Soft delete**
+   - In the diary table delete the edited entry and confirm it disappears while the totals update.
+4. **Export/import**
+   - Export from the diary; inspect the downloaded JSON contains the latest event(s).
+   - Import the same file; toast should read `Импорт: +0, обновлено 0` and no duplicates appear.
+5. **Cross-tab sync**
+   - Open Summary in a second tab. Add sleep on tab A and ensure tab B updates automatically.
+
+(Optional) record a GIF showing adding water and watching the totals update live.

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,56 @@
+# Shared Storage API
+
+A lightweight client-side module that wraps `localStorage` for diary and summary pages. It exposes a `StorageAPI` object globally (for `<script>` usage) and as a CommonJS/AMD export. When imported with ES modules, the default export is the same object.
+
+## Keys
+
+- `LS_EVENTS` – stored JSON array of event objects (`health_events_v1`).
+- `LS_SETTINGS` – stored JSON object with UI preferences (`health_settings_v1`).
+- `SCHEMA_VERSION` – current schema marker (`1`).
+
+## Core methods
+
+- `loadEvents(): Event[]` – returns normalized event list sorted by newest first.
+- `saveEvents(events: Event[]): Event[]` – persists and re-normalizes events.
+- `loadSettings(): object` / `saveSettings(settings: object): object` – read and write settings payloads.
+- `upsertEvents(events: Event[]): { added, updated, total }` – merge incoming events by `id` and `updated_at`.
+- `range(start: Date, end: Date): Event[]` – non-deleted events within the inclusive range.
+- `aggregates(scope, anchor): Summary` – returns totals for `day`, `week`, `month`, or `year` windows.
+- `exportJson(): { events, settings, version }` – copy of stored payloads.
+- `importJson(payload): { added, updated }` – validate, merge, and persist incoming data.
+
+## Events
+
+The module dispatches a `CustomEvent('health:changed', { detail: { target } })` after it mutates storage and when other tabs emit `storage` events. Subscribe on `window` to refresh UIs:
+
+```js
+window.addEventListener('health:changed', (event) => {
+  // event.detail.target is either "events" or "settings"
+  render();
+});
+```
+
+## Utilities
+
+`StorageAPI.utils` exposes helpers:
+
+- `startOfWeek(date)` – Monday start.
+- `startOfMonth(date)`
+- `startOfYear(date)`
+- `endOfDay(date)`
+
+## Event shape
+
+```
+interface Event {
+  id: string;
+  type: string;
+  value_number: number | null;
+  note: string;
+  created_at: string; // ISO
+  updated_at: string; // ISO
+  deleted_at?: string; // ISO
+  // Any other keys from imports are preserved.
+}
+```
+

--- a/shared/nav-loader.js
+++ b/shared/nav-loader.js
@@ -1,0 +1,18 @@
+(function () {
+  async function injectNav() {
+    const container = document.querySelector('[data-include="nav"]');
+    if (!container) return;
+    try {
+      const response = await fetch('./includes/nav.html');
+      container.innerHTML = await response.text();
+    } catch (err) {
+      console.error('Failed to load navigation include', err);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectNav);
+  } else {
+    injectNav();
+  }
+})();

--- a/shared/storage.js
+++ b/shared/storage.js
@@ -1,0 +1,409 @@
+(function (globalFactory) {
+  const api = globalFactory();
+  const globalObject = typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : this);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  if (typeof define === 'function' && define.amd) {
+    define(function () {
+      return api;
+    });
+  }
+  if (globalObject) {
+    globalObject.StorageAPI = api;
+  }
+})(function () {
+  const LS_EVENTS = 'health_events_v1';
+  const LS_SETTINGS = 'health_settings_v1';
+  const SCHEMA_VERSION = 1;
+
+  function nowISO() {
+    return new Date().toISOString();
+  }
+
+  function parseDate(value) {
+    if (!value) return null;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  function clone(obj) {
+    return obj == null ? obj : JSON.parse(JSON.stringify(obj));
+  }
+
+  function safeParse(raw, fallback) {
+    if (!raw) return clone(fallback);
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed;
+    } catch (err) {
+      console.warn('[StorageAPI] Failed to parse JSON for localStorage value', err);
+      return clone(fallback);
+    }
+  }
+
+  function sanitizeEvent(raw) {
+    if (!raw || typeof raw !== 'object') return null;
+    const source = { ...raw };
+    const ensureString = (value, fallback = '') => (typeof value === 'string' ? value : fallback);
+    const ensureNumber = (value) => {
+      if (value == null || value === '') return null;
+      const num = Number(value);
+      return Number.isFinite(num) ? num : null;
+    };
+    const ensureDateIso = (value, fallback) => {
+      const parsed = parseDate(value) || (fallback ? parseDate(fallback) : null);
+      return parsed ? parsed.toISOString() : nowISO();
+    };
+
+    const id = ensureString(source.id, undefined) || generateId();
+    const type = ensureString(source.type, 'generic');
+    const note = ensureString(source.note, '');
+    const valueNumber = ensureNumber(source.value_number);
+    const createdAt = ensureDateIso(source.created_at, source.updated_at);
+    const updatedAt = ensureDateIso(source.updated_at, createdAt);
+    const deletedAt = parseDate(source.deleted_at);
+
+    const normalized = {
+      ...source,
+      id,
+      type,
+      note,
+      value_number: valueNumber,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    };
+    if (deletedAt) {
+      normalized.deleted_at = deletedAt.toISOString();
+    } else {
+      delete normalized.deleted_at;
+    }
+    return normalized;
+  }
+
+  function generateId() {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return `evt_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+  }
+
+  function readArray(key) {
+    const raw = storage().getItem(key);
+    const parsed = safeParse(raw, []);
+    return Array.isArray(parsed) ? parsed : [];
+  }
+
+  function readObject(key) {
+    const raw = storage().getItem(key);
+    const parsed = safeParse(raw, {});
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  }
+
+  function storage() {
+    if (typeof localStorage === 'undefined') {
+      throw new Error('localStorage is not available in this environment');
+    }
+    return localStorage;
+  }
+
+  function dispatchChange(target) {
+    if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+      return;
+    }
+    const detail = { target };
+    const event = createCustomEvent('health:changed', { detail });
+    window.dispatchEvent(event);
+  }
+
+  function createCustomEvent(name, params) {
+    if (typeof CustomEvent === 'function') {
+      return new CustomEvent(name, params);
+    }
+    if (typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+      const event = document.createEvent('CustomEvent');
+      event.initCustomEvent(name, params?.bubbles || false, params?.cancelable || false, params?.detail);
+      return event;
+    }
+    return { type: name, detail: params?.detail };
+  }
+
+  function loadEvents() {
+    const items = readArray(LS_EVENTS).map(sanitizeEvent).filter(Boolean);
+    return items.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+  }
+
+  function saveEvents(events) {
+    const normalized = (Array.isArray(events) ? events : []).map(sanitizeEvent).filter(Boolean);
+    const sorted = normalized.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+    storage().setItem(LS_EVENTS, JSON.stringify(sorted));
+    dispatchChange('events');
+    return sorted;
+  }
+
+  function loadSettings() {
+    const data = readObject(LS_SETTINGS);
+    return data;
+  }
+
+  function saveSettings(settings) {
+    const source = settings && typeof settings === 'object' ? settings : {};
+    storage().setItem(LS_SETTINGS, JSON.stringify(source));
+    dispatchChange('settings');
+    return source;
+  }
+
+  function upsertEvents(incoming) {
+    const list = loadEvents();
+    const map = new Map(list.map((item) => [item.id, item]));
+    let added = 0;
+    let updated = 0;
+    (incoming || []).forEach((raw) => {
+      const next = sanitizeEvent(raw);
+      if (!next) return;
+      const existing = map.get(next.id);
+      if (!existing) {
+        map.set(next.id, next);
+        added += 1;
+        return;
+      }
+      const incomingDate = parseDate(next.updated_at);
+      const existingDate = parseDate(existing.updated_at);
+      if (!existingDate || (incomingDate && incomingDate > existingDate)) {
+        map.set(next.id, { ...existing, ...next, updated_at: incomingDate ? incomingDate.toISOString() : nowISO() });
+        updated += 1;
+      }
+    });
+    const merged = Array.from(map.values());
+    saveEvents(merged);
+    return { added, updated, total: merged.length };
+  }
+
+  function exportJson() {
+    return {
+      version: SCHEMA_VERSION,
+      events: loadEvents(),
+      settings: loadSettings(),
+    };
+  }
+
+  function importJson(payload) {
+    const result = { added: 0, updated: 0 };
+    if (!payload || typeof payload !== 'object') {
+      return result;
+    }
+    const events = Array.isArray(payload.events) ? payload.events : [];
+    const settings = payload.settings && typeof payload.settings === 'object' ? payload.settings : null;
+    const { added, updated } = upsertEvents(events);
+    result.added = added;
+    result.updated = updated;
+    if (settings) {
+      const current = loadSettings();
+      saveSettings({ ...current, ...settings });
+    }
+    return result;
+  }
+
+  function range(start, end) {
+    const startDate = start ? new Date(start) : null;
+    const endDate = end ? new Date(end) : null;
+    return loadEvents().filter((event) => {
+      if (event.deleted_at) return false;
+      const created = parseDate(event.created_at);
+      if (!created) return false;
+      if (startDate && created < startDate) return false;
+      if (endDate && created > endDate) return false;
+      return true;
+    });
+  }
+
+  function aggregates(scope, anchor) {
+    const reference = anchor ? new Date(anchor) : new Date();
+    const { start, end } = resolveScope(scope, reference);
+    const items = range(start, end);
+    const summary = {
+      water_ml: 0,
+      caffeine_mg: 0,
+      steps: 0,
+      sleep_min: 0,
+      stress_avg: 0,
+      energy_avg: 0,
+      srv_avg: 0,
+      meds_count: 0,
+    };
+    const counters = {
+      stress: 0,
+      energy: 0,
+      srv: 0,
+    };
+
+    items.forEach((event) => {
+      const val = typeof event.value_number === 'number' ? event.value_number : null;
+      switch (event.type) {
+        case 'water':
+          if (val != null) summary.water_ml += val;
+          break;
+        case 'caffeine':
+          if (val != null) summary.caffeine_mg += val;
+          break;
+        case 'steps':
+          if (val != null) summary.steps += val;
+          break;
+        case 'sleep':
+          if (val != null) summary.sleep_min += val;
+          break;
+        case 'stress':
+          if (val != null) {
+            summary.stress_avg += val;
+            counters.stress += 1;
+          }
+          break;
+        case 'energy':
+          if (val != null) {
+            summary.energy_avg += val;
+            counters.energy += 1;
+          }
+          break;
+        case 'srv':
+          if (val != null) {
+            summary.srv_avg += val;
+            counters.srv += 1;
+          }
+          break;
+        case 'med':
+        case 'medication':
+          summary.meds_count += 1;
+          break;
+        default:
+          break;
+      }
+    });
+
+    summary.stress_avg = counters.stress ? +(summary.stress_avg / counters.stress).toFixed(2) : 0;
+    summary.energy_avg = counters.energy ? +(summary.energy_avg / counters.energy).toFixed(2) : 0;
+    summary.srv_avg = counters.srv ? +(summary.srv_avg / counters.srv).toFixed(2) : 0;
+
+    return summary;
+  }
+
+  function resolveScope(scope, anchor) {
+    const reference = anchor instanceof Date ? anchor : new Date();
+    let start;
+    switch (scope) {
+      case 'week':
+        start = startOfWeek(reference);
+        break;
+      case 'month':
+        start = startOfMonth(reference);
+        break;
+      case 'year':
+        start = startOfYear(reference);
+        break;
+      case 'day':
+      default:
+        start = startOfDay(reference);
+        break;
+    }
+    const end = endOfDay(
+      scope === 'day'
+        ? reference
+        : scope === 'week'
+          ? addDays(start, 6)
+          : scope === 'month'
+            ? endOfMonth(start)
+            : endOfYear(start)
+    );
+    return { start, end };
+  }
+
+  function startOfDay(date) {
+    const d = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+
+  function endOfDay(date) {
+    const d = new Date(date);
+    d.setHours(23, 59, 59, 999);
+    return d;
+  }
+
+  function startOfWeek(date) {
+    const d = startOfDay(date);
+    const day = d.getDay();
+    const diff = (day + 6) % 7; // Monday as start of week
+    d.setDate(d.getDate() - diff);
+    return d;
+  }
+
+  function startOfMonth(date) {
+    const d = startOfDay(date);
+    d.setDate(1);
+    return d;
+  }
+
+  function startOfYear(date) {
+    const d = startOfDay(date);
+    d.setMonth(0, 1);
+    return d;
+  }
+
+  function endOfMonth(date) {
+    const d = startOfMonth(date);
+    d.setMonth(d.getMonth() + 1);
+    d.setMilliseconds(-1);
+    return d;
+  }
+
+  function endOfYear(date) {
+    const d = startOfYear(date);
+    d.setFullYear(d.getFullYear() + 1);
+    d.setMilliseconds(-1);
+    return d;
+  }
+
+  function addDays(date, days) {
+    const d = new Date(date);
+    d.setDate(d.getDate() + days);
+    return d;
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', (event) => {
+      if (!event) return;
+      if (event.key === LS_EVENTS) {
+        dispatchChange('events');
+      }
+      if (event.key === LS_SETTINGS) {
+        dispatchChange('settings');
+      }
+    });
+  }
+
+  const api = {
+    LS_EVENTS,
+    LS_SETTINGS,
+    SCHEMA_VERSION,
+    loadEvents,
+    saveEvents,
+    loadSettings,
+    saveSettings,
+    upsertEvents,
+    exportJson,
+    importJson,
+    range,
+    aggregates,
+    utils: {
+      startOfWeek,
+      startOfMonth,
+      startOfYear,
+      endOfDay,
+    },
+  };
+
+  api.__esModule = true;
+  api.default = api;
+
+  return api;
+});
+

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -1,0 +1,182 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #f4f6f8;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  background: var(--page-bg, #f4f6f8);
+  color: inherit;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: #0f172a;
+  color: #fff;
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.1);
+}
+
+.site-nav a {
+  color: inherit;
+  text-decoration: none;
+  margin-right: 1rem;
+  font-weight: 600;
+}
+
+.site-nav__brand {
+  font-size: 1.125rem;
+}
+
+.site-nav__links a:last-child {
+  margin-right: 0;
+}
+
+main {
+  padding: 2rem;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+}
+
+.card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.card strong {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+  background: #fff;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table thead {
+  background: #e2e8f0;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+table th,
+table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+table td input,
+table td textarea,
+table td select {
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.button,
+button {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.button.secondary,
+button.secondary {
+  background: #64748b;
+}
+
+button.danger {
+  background: #dc2626;
+}
+
+form {
+  display: grid;
+  gap: 0.75rem;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+  margin-bottom: 2rem;
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.form-row > * {
+  flex: 1;
+  min-width: 180px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  padding: 0.8rem 1.2rem;
+  border-radius: 8px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 640px) {
+  .site-nav {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  main {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a shared StorageAPI module for events/settings with import/export helpers and cross-tab sync
- wire new Diary and Summary pages to the shared storage layer, keeping aggregates and inline editing
- add shared navigation, pocket landing page, offline README guidance, and smoke checklist docs

## Testing
- Manual smoke test (Summary quick action -> Diary totals)


------
https://chatgpt.com/codex/tasks/task_e_68e54d9be0e4833285c9190bbfa118aa