### PR TITLE
Refresh sidebar navigation and map experience

### DIFF
--- a/DiaryPlus.html
+++ b/DiaryPlus.html
@@ -8,7 +8,7 @@
     <link rel="manifest" href="./manifest.webmanifest" />
     <link rel="stylesheet" href="./shared/styles.css" />
   </head>
-  <body class="app-shell">
+  <body class="app-shell" data-page="diary">
     <div data-include="nav"></div>
     <main class="app-main">
       <div class="container flow">

--- a/Map.html
+++ b/Map.html
@@ -1,327 +1,451 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Map</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Map</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+      defer
+    ></script>
+  </head>
+  <body class="app-shell" data-page="map">
+    <div data-include="nav"></div>
+    <main class="app-main">
+      <div class="container flow">
+        <header class="page-header">
+          <span class="page-header__eyebrow">Map</span>
+          <h1>Location snapshots</h1>
+          <p>
+            Capture quick snapshots tied to your current location, explore them on the map,
+            and sync changes instantly across tabs.
+          </p>
+          <span class="badge">Spatial memory</span>
+        </header>
 
-  <!-- ваш общий стиль (можно убрать, если нет) -->
-  <link rel="stylesheet" href="./shared/styles.css" />
-
-  <!-- Leaflet -->
-  <link rel="stylesheet"
-        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-          integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-
-  <style>
-    body { margin:0; padding:16px; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    .toolbar { display:flex; flex-wrap:wrap; gap:.5rem; align-items:center; margin:0 0 .75rem 0; }
-    .toolbar input[type="date"]{ padding:.5rem .6rem; border:1px solid #e2e8f0; border-radius:.6rem; }
-    .btn { padding:.55rem .8rem; border-radius:.6rem; border:1px solid #cbd5e1; cursor:pointer; background:#fff; }
-    .btn.primary { background:#2563eb; color:#fff; border-color:#2563eb; }
-    .btn:disabled { opacity:.5; cursor:not-allowed; }
-    #map { width:100%; min-height:420px; height:62vh; border-radius:16px; }
-    .layout { display:grid; grid-template-columns: 1fr 340px; gap:1rem; }
-    @media (max-width: 980px){ .layout { grid-template-columns: 1fr; } #map{ height:56vh; } }
-    .panel { border:1px solid #e5e7eb; border-radius:14px; padding:.75rem; background:#fff; }
-    .list { max-height:60vh; overflow:auto; margin:0; padding:0; list-style:none; }
-    .item { border-bottom:1px solid #f1f5f9; padding:.6rem .3rem; display:flex; gap:.5rem; align-items:center; }
-    .item:last-child{ border-bottom:none; }
-    .item button { margin-left:auto; }
-    .muted { color:#64748b; font-size:.9rem; }
-    .search { width:100%; padding:.5rem .6rem; border:1px solid #e2e8f0; border-radius:.6rem; }
-  </style>
-</head>
-<body>
-  <h1 style="margin:0 0 12px 0;">Location snapshots</h1>
-
-  <!-- панель управления -->
-  <div class="toolbar">
-    <button id="btnLocate" class="btn">My location</button>
-    <button id="btnSnap" class="btn primary">Snapshot</button>
-
-    <input id="inpDate" type="date"/>
-    <button class="btn" data-scope="day">Day</button>
-    <button class="btn" data-scope="week">Week</button>
-    <button class="btn" data-scope="month">Month</button>
-
-    <input id="inpSearch" class="search" placeholder="Search by note" style="flex:1 1 220px; max-width:420px;">
-    <button id="btnExport" class="btn">Export JSON</button>
-    <button id="btnImport" class="btn">Import JSON</button>
-    <input id="fileImport" type="file" accept="application/json" style="display:none;">
-  </div>
-
-  <div class="layout">
-    <div id="map"></div>
-
-    <div class="panel">
-      <div class="muted" style="margin-bottom:.5rem;">History</div>
-      <ul id="list" class="list"></ul>
-    </div>
-  </div>
-
-  <script>
-  // ===== Local storage API for locations =====
-  const LS_LOCATIONS = 'health_locations_v1';
-  const nowIso = () => new Date().toISOString();
-  const uuid = () => (crypto.randomUUID ? crypto.randomUUID() :
-                     'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c=>{
-                        const r=Math.random()*16|0, v=c==='x'?r:(r&0x3|0x8); return v.toString(16);
-                     }));
-
-  function loadLocations(){
-    try { return JSON.parse(localStorage.getItem(LS_LOCATIONS) || '[]'); }
-    catch(e){ return []; }
-  }
-  function saveLocations(arr){
-    localStorage.setItem(LS_LOCATIONS, JSON.stringify(arr));
-    // кросс-синк
-    window.dispatchEvent(new CustomEvent('health:changed'));
-  }
-  function addLocation(loc){
-    const arr = loadLocations();
-    const item = { id: uuid(), note:'', source:'device', created_at: nowIso(), updated_at: nowIso(), ...loc };
-    arr.push(item); saveLocations(arr); return item;
-  }
-  function updateLocation(id, patch){
-    const arr = loadLocations();
-    const i = arr.findIndex(x=>x.id===id);
-    if(i>=0){ arr[i] = { ...arr[i], ...patch, updated_at: nowIso() }; saveLocations(arr); }
-  }
-  function deleteLocation(id){
-    const arr = loadLocations().filter(x=>x.id!==id); saveLocations(arr);
-  }
-
-  // ===== date helpers =====
-  function startOfDay(d){ const x=new Date(d); x.setHours(0,0,0,0); return x; }
-  function endOfDay(d){ const x=new Date(d); x.setHours(23,59,59,999); return x; }
-  function startOfWeek(d){ const x=new Date(d); const wd=(x.getDay()+6)%7; x.setDate(x.getDate()-wd); x.setHours(0,0,0,0); return x; }
-  function endOfWeek(d){ const x=startOfWeek(d); x.setDate(x.getDate()+6); x.setHours(23,59,59,999); return x; }
-  function startOfMonth(d){ const x=new Date(d.getFullYear(), d.getMonth(), 1); x.setHours(0,0,0,0); return x; }
-  function endOfMonth(d){ const x=new Date(d.getFullYear(), d.getMonth()+1, 0); x.setHours(23,59,59,999); return x; }
-
-  // ===== Map =====
-  let map, markersLayer;
-  let scope = 'day';
-  let anchor = new Date();
-
-  const inpDate = document.getElementById('inpDate');
-  inpDate.valueAsDate = anchor;
-
-  function initMap(){
-    // начальный центр — либо последняя точка, либо Амстердам
-    const last = loadLocations().slice(-1)[0];
-    const center = last ? [last.lat, last.lng] : [52.37, 4.89];
-    map = L.map('map').setView(center, last ? 13 : 12);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 19, attribution: '© OpenStreetMap'
-    }).addTo(map);
-    markersLayer = L.layerGroup().addTo(map);
-    setTimeout(()=>map.invalidateSize(), 0);
-  }
-
-  function rangeForScope(sc, d){
-    if(sc==='day') return [startOfDay(d), endOfDay(d)];
-    if(sc==='week') return [startOfWeek(d), endOfWeek(d)];
-    return [startOfMonth(d), endOfMonth(d)];
-  }
-
-  function render(){
-    markersLayer.clearLayers();
-    const [a,b] = rangeForScope(scope, anchor);
-    const q = (document.getElementById('inpSearch').value || '').toLowerCase().trim();
-
-    let arr = loadLocations().filter(x=>{
-      const t = new Date(x.created_at).getTime();
-      return t>=a.getTime() && t<=b.getTime();
-    });
-    if(q) arr = arr.filter(x => (x.note||'').toLowerCase().includes(q));
-
-    // markers
-    arr.forEach(x=>{
-      const m = L.marker([x.lat, x.lng]).addTo(markersLayer);
-      const when = new Date(x.created_at).toLocaleString();
-      m.bindPopup(`<b>${when}</b><br>accuracy: ${x.accuracy_m??'—'} m<br>${(x.note||'')}`);
-      m.on('click', ()=> m.openPopup());
-    });
-
-    // list
-    const ul = document.getElementById('list');
-    ul.innerHTML = '';
-    if(arr.length===0){
-      ul.innerHTML = `<li class="item"><span class="muted">0 snapshots</span></li>`;
-    } else {
-      arr.sort((a,b)=> new Date(b.created_at)-new Date(a.created_at));
-      arr.forEach(x=>{
-        const li = document.createElement('li'); li.className='item';
-        const when = new Date(x.created_at).toLocaleString();
-        li.innerHTML = `
-          <div>
-            <div><b>${when}</b></div>
-            <div class="muted">${x.lat.toFixed(5)}, ${x.lng.toFixed(5)} · acc ${x.accuracy_m??'—'} m</div>
-            <div contenteditable="true" data-id="${x.id}" class="muted" style="outline:none">${x.note||''}</div>
+        <div class="toolbar">
+          <button id="btnLocate" class="btn ghost" type="button">My location</button>
+          <button id="btnSnap" class="btn primary" type="button">Snapshot</button>
+          <input id="inpDate" type="date" class="input" />
+          <div class="chip-group" role="group" aria-label="Filter by range">
+            <button class="chip active" data-scope="day" type="button">Day</button>
+            <button class="chip" data-scope="week" type="button">Week</button>
+            <button class="chip" data-scope="month" type="button">Month</button>
           </div>
-          <button class="btn" data-action="focus" data-id="${x.id}">Focus</button>
-          <button class="btn" data-action="delete" data-id="${x.id}">Delete</button>
-        `;
-        ul.appendChild(li);
-      });
-    }
-  }
+          <input
+            id="inpSearch"
+            class="input search-field"
+            placeholder="Search by note"
+            type="search"
+            aria-label="Search snapshots"
+          />
+          <button id="btnExport" class="btn ghost" type="button">Export JSON</button>
+          <button id="btnImport" class="btn ghost" type="button">Import JSON</button>
+          <input id="fileImport" type="file" accept="application/json" />
+        </div>
 
-  // ===== actions =====
-  document.getElementById('btnLocate').onclick = () => {
-    if(!('geolocation' in navigator)){
-      alert('Geolocation is not available'); return;
-    }
-    navigator.geolocation.getCurrentPosition(
-      pos => map.flyTo([pos.coords.latitude, pos.coords.longitude], 15),
-      err => alert('Geolocation error: ' + err.message),
-      { enableHighAccuracy:true, maximumAge:5000, timeout:15000 }
-    );
-  };
+        <div class="map-layout">
+          <div id="map" class="map" aria-label="Locations map"></div>
+          <aside class="panel" aria-label="Snapshot history">
+            <div class="muted" style="margin-bottom: 0.5rem;">History</div>
+            <ul id="list" class="list"></ul>
+          </aside>
+        </div>
+      </div>
+    </main>
 
-  document.getElementById('btnSnap').onclick = () => {
-    const save = (lat,lng,acc,source) => {
-      const item = addLocation({ lat, lng, accuracy_m: acc, source });
-      // быстрый маркер и фокус
-      L.marker([item.lat, item.lng]).addTo(markersLayer);
-      map.flyTo([item.lat, item.lng], 16);
-      render();
-    };
-    if('geolocation' in navigator){
-      navigator.geolocation.getCurrentPosition(
-        pos => save(pos.coords.latitude, pos.coords.longitude, Math.round(pos.coords.accuracy||0), 'device'),
-        _err => { // без разрешения — центр карты
-          const c = map.getCenter(); save(c.lat, c.lng, null, 'manual');
-        },
-        { enableHighAccuracy:true, maximumAge:5000, timeout:8000 }
-      );
-    } else {
-      const c = map.getCenter(); save(c.lat, c.lng, null, 'manual');
-    }
-  };
+    <script src="./shared/nav-loader.js" defer></script>
+    <script>
+      (function () {
+        const LS_LOCATIONS = 'health_locations_v1';
+        const nowIso = () => new Date().toISOString();
+        const uuid = () =>
+          (crypto.randomUUID
+            ? crypto.randomUUID()
+            : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+                const r = (Math.random() * 16) | 0;
+                const v = c === 'x' ? r : (r & 0x3) | 0x8;
+                return v.toString(16);
+              }));
 
-  // смена даты/диапазона/поиска
-  inpDate.onchange = () => { anchor = inpDate.valueAsDate || new Date(); render(); };
-  document.querySelectorAll('[data-scope]').forEach(btn=>{
-    btn.onclick = () => { scope = btn.dataset.scope; render(); };
-  });
-  document.getElementById('inpSearch').oninput = () => render();
+        function loadLocations() {
+          try {
+            return JSON.parse(localStorage.getItem(LS_LOCATIONS) || '[]');
+          } catch (error) {
+            console.warn('Failed to parse stored locations', error);
+            return [];
+          }
+        }
 
-  // список: фокус / удаление / редактирование заметки
-  document.getElementById('list').onclick = (e)=>{
-    const id = e.target.dataset.id;
-    if(!id) return;
-    if(e.target.dataset.action==='delete'){ deleteLocation(id); render(); }
-    if(e.target.dataset.action==='focus'){
-      const x = loadLocations().find(z=>z.id===id);
-      if(x){ map.flyTo([x.lat, x.lng], 16); }
-    }
-  };
-  // сохранение заметки (по выходу из фокуса)
-  document.getElementById('list').addEventListener('focusout', (e)=>{
-    const id = e.target.dataset.id;
-    if(id){ updateLocation(id, { note: e.target.innerText.trim() }); render(); }
-  });
+        function saveLocations(entries) {
+          localStorage.setItem(LS_LOCATIONS, JSON.stringify(entries));
+          window.dispatchEvent(new CustomEvent('health:changed'));
+        }
 
-  // экспорт/импорт
-  document.getElementById('btnExport').onclick = ()=>{
-    const data = { version:1, locations: loadLocations() };
-    const blob = new Blob([JSON.stringify(data, null, 2)], {type:'application/json'});
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = `locations_${new Date().toISOString().slice(0,10)}.json`;
-    a.click(); URL.revokeObjectURL(a.href);
-  };
-  document.getElementById('btnImport').onclick = ()=> document.getElementById('fileImport').click();
-  document.getElementById('fileImport').onchange = async (e)=>{
-    const file = e.target.files[0]; if(!file) return;
-    const text = await file.text();
-    try{
-      const incoming = JSON.parse(text).locations || [];
-      const mapById = new Map(loadLocations().map(x=>[x.id,x]));
-      incoming.forEach(x=>{
-        const ex = mapById.get(x.id);
-        if(!ex || new Date(x.updated_at) > new Date(ex.updated_at)) mapById.set(x.id, x);
-      });
-      saveLocations([...mapById.values()]); render();
-      alert(`Imported ${incoming.length} snapshots`);
-    }catch(err){ alert('Invalid JSON'); }
-    e.target.value = '';
-  };
+        function addLocation(data) {
+          const entries = loadLocations();
+          const item = {
+            id: uuid(),
+            note: '',
+            source: 'device',
+            created_at: nowIso(),
+            updated_at: nowIso(),
+            ...data,
+          };
+          entries.push(item);
+          saveLocations(entries);
+          return item;
+        }
 
-  // кросс-вкладки
-  window.addEventListener('storage', (e)=>{ if(e.key===LS_LOCATIONS) render(); });
-  window.addEventListener('health:changed', render);
+        function updateLocation(id, patch) {
+          const entries = loadLocations();
+          const index = entries.findIndex((entry) => entry.id === id);
+          if (index >= 0) {
+            entries[index] = { ...entries[index], ...patch, updated_at: nowIso() };
+            saveLocations(entries);
+          }
+        }
 
-  // init
-  initMap(); render();
-  </script>
-</body>
+        function deleteLocation(id) {
+          const next = loadLocations().filter((entry) => entry.id !== id);
+          saveLocations(next);
+        }
+
+        function startOfDay(date) {
+          const next = new Date(date);
+          next.setHours(0, 0, 0, 0);
+          return next;
+        }
+
+        function endOfDay(date) {
+          const next = new Date(date);
+          next.setHours(23, 59, 59, 999);
+          return next;
+        }
+
+        function startOfWeek(date) {
+          const next = new Date(date);
+          const weekday = (next.getDay() + 6) % 7;
+          next.setDate(next.getDate() - weekday);
+          next.setHours(0, 0, 0, 0);
+          return next;
+        }
+
+        function endOfWeek(date) {
+          const next = startOfWeek(date);
+          next.setDate(next.getDate() + 6);
+          next.setHours(23, 59, 59, 999);
+          return next;
+        }
+
+        function startOfMonth(date) {
+          const next = new Date(date.getFullYear(), date.getMonth(), 1);
+          next.setHours(0, 0, 0, 0);
+          return next;
+        }
+
+        function endOfMonth(date) {
+          const next = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+          next.setHours(23, 59, 59, 999);
+          return next;
+        }
+
+        function rangeForScope(value, date) {
+          if (value === 'day') return [startOfDay(date), endOfDay(date)];
+          if (value === 'week') return [startOfWeek(date), endOfWeek(date)];
+          return [startOfMonth(date), endOfMonth(date)];
+        }
+
+        let map;
+        let markersLayer;
+        let meMarker = null;
+        let meCircle = null;
+        let scope = 'day';
+        let anchor = new Date();
+
+        const elements = {
+          date: document.getElementById('inpDate'),
+          search: document.getElementById('inpSearch'),
+          list: document.getElementById('list'),
+          locate: document.getElementById('btnLocate'),
+          snapshot: document.getElementById('btnSnap'),
+          scopeButtons: Array.from(document.querySelectorAll('[data-scope]')),
+          importInput: document.getElementById('fileImport'),
+          importBtn: document.getElementById('btnImport'),
+          exportBtn: document.getElementById('btnExport'),
+        };
+
+        elements.date.valueAsDate = anchor;
+
+        function initMap() {
+          const last = loadLocations().slice(-1)[0];
+          const center = last ? [last.lat, last.lng] : [52.37, 4.89];
+          map = L.map('map');
+          map.setView(center, last ? 13 : 12);
+          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '© OpenStreetMap',
+          }).addTo(map);
+          markersLayer = L.layerGroup().addTo(map);
+          setTimeout(() => map.invalidateSize(), 0);
+        }
+
+        function updateCurrentPosition(lat, lng, accuracy) {
+          if (!map) return;
+          if (meMarker) {
+            map.removeLayer(meMarker);
+            meMarker = null;
+          }
+          if (meCircle) {
+            map.removeLayer(meCircle);
+            meCircle = null;
+          }
+
+          meMarker = L.circleMarker([lat, lng], {
+            radius: 7,
+            color: '#2563eb',
+            fillColor: '#2563eb',
+            fillOpacity: 1,
+            weight: 2,
+          }).addTo(map);
+
+          if (typeof accuracy === 'number' && Number.isFinite(accuracy) && accuracy > 0) {
+            meCircle = L.circle([lat, lng], {
+              radius: accuracy,
+              color: '#60a5fa',
+              fillColor: '#93c5fd',
+              fillOpacity: 0.15,
+              weight: 1,
+            }).addTo(map);
+          }
+        }
+
+        function filterLocations() {
+          const [start, end] = rangeForScope(scope, anchor);
+          const query = (elements.search.value || '').toLowerCase().trim();
+          return loadLocations().filter((entry) => {
+            const time = new Date(entry.created_at).getTime();
+            const inRange = time >= start.getTime() && time <= end.getTime();
+            if (!inRange) return false;
+            if (!query) return true;
+            return (entry.note || '').toLowerCase().includes(query);
+          });
+        }
+
+        function render() {
+          const items = filterLocations();
+          if (markersLayer) {
+            markersLayer.clearLayers();
+
+            items.forEach((entry) => {
+              const marker = L.marker([entry.lat, entry.lng]).addTo(markersLayer);
+              const when = new Date(entry.created_at).toLocaleString();
+              marker.bindPopup(
+                `<b>${when}</b><br>accuracy: ${entry.accuracy_m ?? '—'} m<br>${entry.note || ''}`
+              );
+            });
+          }
+
+          elements.list.innerHTML = '';
+          if (!items.length) {
+            const empty = document.createElement('li');
+            empty.className = 'item';
+            empty.innerHTML = '<span class="muted">0 snapshots</span>';
+            elements.list.appendChild(empty);
+            return;
+          }
+
+          items
+            .slice()
+            .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+            .forEach((entry) => {
+              const li = document.createElement('li');
+              li.className = 'item';
+              const when = new Date(entry.created_at).toLocaleString();
+              li.innerHTML = `
+                <div>
+                  <div><strong>${when}</strong></div>
+                  <div class="muted">${entry.lat.toFixed(5)}, ${entry.lng.toFixed(5)} · acc ${
+                entry.accuracy_m ?? '—'
+              } m</div>
+                  <div class="muted" contenteditable="true" data-id="${entry.id}" style="outline:none;">${
+                entry.note || ''
+              }</div>
+                </div>
+                <button class="btn ghost" data-action="focus" data-id="${entry.id}" type="button">Focus</button>
+                <button class="btn" data-action="delete" data-id="${entry.id}" type="button">Delete</button>
+              `;
+              elements.list.appendChild(li);
+            });
+        }
+
+        function focusOn(lat, lng) {
+          if (map) {
+            map.flyTo([lat, lng], 16);
+          }
+        }
+
+        function showCurrentPosition() {
+          if (!('geolocation' in navigator)) {
+            alert('Geolocation is not available');
+            return;
+          }
+          navigator.geolocation.getCurrentPosition(
+            (pos) => {
+              const lat = pos.coords.latitude;
+              const lng = pos.coords.longitude;
+              const acc = Math.round(pos.coords.accuracy || 0);
+              updateCurrentPosition(lat, lng, acc);
+              focusOn(lat, lng);
+            },
+            (error) => {
+              alert('Geolocation error: ' + error.message);
+            },
+            { enableHighAccuracy: true, maximumAge: 5000, timeout: 15000 }
+          );
+        }
+
+        function snapshotFrom(lat, lng, accuracy, source) {
+          const item = addLocation({ lat, lng, accuracy_m: accuracy, source });
+          if (markersLayer) {
+            L.marker([item.lat, item.lng]).addTo(markersLayer);
+          }
+          focusOn(item.lat, item.lng);
+          render();
+        }
+
+        function snapshotFromCenter() {
+          const center = map?.getCenter();
+          if (!center) return;
+          snapshotFrom(center.lat, center.lng, null, 'manual');
+        }
+
+        function snapshot() {
+          if (!('geolocation' in navigator)) {
+            snapshotFromCenter();
+            return;
+          }
+          navigator.geolocation.getCurrentPosition(
+            (pos) => {
+              const lat = pos.coords.latitude;
+              const lng = pos.coords.longitude;
+              const acc = Math.round(pos.coords.accuracy || 0);
+              updateCurrentPosition(lat, lng, acc);
+              snapshotFrom(lat, lng, acc, 'device');
+            },
+            () => snapshotFromCenter(),
+            { enableHighAccuracy: true, maximumAge: 5000, timeout: 8000 }
+          );
+        }
+
+        elements.locate?.addEventListener('click', showCurrentPosition);
+        elements.snapshot?.addEventListener('click', snapshot);
+
+        elements.date.addEventListener('change', () => {
+          anchor = elements.date.valueAsDate || new Date();
+          render();
+        });
+
+        elements.scopeButtons.forEach((button) => {
+          button.addEventListener('click', () => {
+            scope = button.dataset.scope;
+            elements.scopeButtons.forEach((item) =>
+              item.classList.toggle('active', item.dataset.scope === scope)
+            );
+            render();
+          });
+        });
+
+        elements.search.addEventListener('input', () => render());
+
+        elements.list.addEventListener('click', (event) => {
+          const target = event.target;
+          if (!(target instanceof HTMLElement)) return;
+          const { action, id } = target.dataset;
+          if (!id) return;
+          if (action === 'delete') {
+            deleteLocation(id);
+            render();
+          }
+          if (action === 'focus') {
+            const item = loadLocations().find((entry) => entry.id === id);
+            if (item) {
+              focusOn(item.lat, item.lng);
+            }
+          }
+        });
+
+        elements.list.addEventListener('focusout', (event) => {
+          const target = event.target;
+          if (!(target instanceof HTMLElement)) return;
+          const id = target.dataset.id;
+          if (!id) return;
+          updateLocation(id, { note: target.innerText.trim() });
+          render();
+        });
+
+        elements.exportBtn.addEventListener('click', () => {
+          const data = { version: 1, locations: loadLocations() };
+          const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+          const url = URL.createObjectURL(blob);
+          const anchorEl = document.createElement('a');
+          anchorEl.href = url;
+          anchorEl.download = `locations_${new Date().toISOString().slice(0, 10)}.json`;
+          anchorEl.click();
+          URL.revokeObjectURL(url);
+        });
+
+        elements.importBtn.addEventListener('click', () => elements.importInput.click());
+
+        elements.importInput.addEventListener('change', async (event) => {
+          const file = event.target.files?.[0];
+          if (!file) return;
+          const text = await file.text();
+          try {
+            const incoming = JSON.parse(text).locations || [];
+            const current = new Map(loadLocations().map((entry) => [entry.id, entry]));
+            incoming.forEach((entry) => {
+              const existing = current.get(entry.id);
+              if (!existing || new Date(entry.updated_at) > new Date(existing.updated_at)) {
+                current.set(entry.id, entry);
+              }
+            });
+            saveLocations([...current.values()]);
+            render();
+            alert(`Imported ${incoming.length} snapshots`);
+          } catch (error) {
+            alert('Invalid JSON');
+          }
+          event.target.value = '';
+        });
+
+        window.addEventListener('storage', (event) => {
+          if (event.key === LS_LOCATIONS) {
+            render();
+          }
+        });
+        window.addEventListener('health:changed', render);
+
+        function bootstrap() {
+          if (typeof L === 'undefined') {
+            requestAnimationFrame(bootstrap);
+            return;
+          }
+          initMap();
+          render();
+        }
+
+        bootstrap();
+      })();
+    </script>
+  </body>
 </html>
-<script>
-/* --- текущая позиция: синяя точка + круг точности --- */
-let meMarker = null, meCircle = null;
-
-function showCurrentPosition() {
-  if (!('geolocation' in navigator)) {
-    alert('Geolocation is not available on this device/browser.');
-    return;
-  }
-  navigator.geolocation.getCurrentPosition(
-    (pos) => {
-      const lat = pos.coords.latitude;
-      const lng = pos.coords.longitude;
-      const acc = Math.round(pos.coords.accuracy || 0);
-
-      if (meMarker) { map.removeLayer(meMarker); }
-      if (meCircle) { map.removeLayer(meCircle); }
-
-      // синяя точка в центре
-      meMarker = L.circleMarker([lat, lng], {
-        radius: 7, color: '#2563eb', fillColor: '#2563eb', fillOpacity: 1, weight: 2
-      }).addTo(map);
-
-      // круг точности
-      meCircle = L.circle([lat, lng], {
-        radius: acc, color: '#60a5fa', fillColor: '#93c5fd', fillOpacity: 0.15, weight: 1
-      }).addTo(map);
-
-      map.flyTo([lat, lng], 16);
-    },
-    (err) => {
-      alert('Geolocation error: ' + err.message + '\nРазреши доступ к геолокации.');
-    },
-    { enableHighAccuracy: true, maximumAge: 5000, timeout: 15000 }
-  );
-}
-
-// привяжем к кнопке
-document.getElementById('btnLocate')?.addEventListener('click', showCurrentPosition);
-
-/* --- опционально: снапшот берёт текущую позицию, если она известна --- */
-function snapshotFromCurrentOrCenter() {
-  const center = map.getCenter();
-  const fromCurrent = meMarker?.getLatLng() || null;
-  const lat = fromCurrent ? fromCurrent.lat : center.lat;
-  const lng = fromCurrent ? fromCurrent.lng : center.lng;
-  const acc = meCircle ? meCircle.getRadius() : null;
-
-  // если у тебя уже есть свой addLocation(...) — оставь его
-  if (typeof addLocation === 'function') {
-    const item = addLocation({ lat, lng, accuracy_m: acc, source: fromCurrent ? 'device' : 'manual' });
-    L.marker([item.lat, item.lng]).addTo(markersLayer || map);
-    map.flyTo([item.lat, item.lng], 16);
-    if (typeof render === 'function') render();
-  } else {
-    // временный маркер, если хранилища пока нет
-    L.marker([lat, lng]).addTo(map).bindPopup('Snapshot').openPopup();
-  }
-}
-
-// если у тебя кнопка Snapshot имеет id="btnSnap"
-document.getElementById('btnSnap')?.addEventListener('click', snapshotFromCurrentOrCenter);
-</script>

--- a/Summary.html
+++ b/Summary.html
@@ -8,7 +8,7 @@
     <link rel="manifest" href="./manifest.webmanifest" />
     <link rel="stylesheet" href="./shared/styles.css" />
   </head>
-  <body class="app-shell">
+  <body class="app-shell" data-page="summary">
     <div data-include="nav"></div>
     <main class="app-main">
       <div class="container flow">

--- a/includes/nav.html
+++ b/includes/nav.html
@@ -1,8 +1,11 @@
-<nav class="site-nav">
-  <a class="site-nav__brand" href="./pocket_health_link.html">Health2099</a>
-  <div class="site-nav__links">
-    <a href="./Summary.html">Summary</a>
-    <a href="./DiaryPlus.html">Diary</a>
-    <a href="./Map.html">Map</a>
+<aside class="sidebar">
+  <div class="brand">
+    <a class="brand-link" href="Summary.html">Health • 2099</a>
   </div>
-</nav>
+
+  <nav class="nav" aria-label="Primary">
+    <a href="Summary.html" data-nav="summary" class="nav-link"><span>Summary</span></a>
+    <a href="DiaryPlus.html" data-nav="diary" class="nav-link"><span>Diary</span></a>
+    <a href="Map.html" data-nav="map" class="nav-link"><span>Map</span></a>
+  </nav>
+</aside>

--- a/pocket_health_link.html
+++ b/pocket_health_link.html
@@ -8,7 +8,7 @@
     <link rel="manifest" href="./manifest.webmanifest" />
     <link rel="stylesheet" href="./shared/styles.css" />
   </head>
-  <body class="app-shell">
+  <body class="app-shell" data-page="links">
     <div data-include="nav"></div>
     <main class="app-main">
       <div class="container">

--- a/service-worker.js
+++ b/service-worker.js
@@ -17,6 +17,8 @@ const APP_SHELL = [
   './service-worker.js'
 ];
 
+const BYPASS_HOSTS = ['tile.openstreetmap.org', 'unpkg.com'];
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)).then(() => self.skipWaiting())
@@ -38,11 +40,9 @@ self.addEventListener('fetch', (event) => {
   }
 
   const url = new URL(event.request.url);
-  const isBypassedHost =
-    url.hostname === 'unpkg.com' || url.hostname.endsWith('.tile.openstreetmap.org') || url.hostname === 'tile.openstreetmap.org';
+  const shouldBypass = BYPASS_HOSTS.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`));
 
-  if (isBypassedHost) {
-    event.respondWith(fetch(event.request));
+  if (shouldBypass) {
     return;
   }
 

--- a/shared/nav-loader.js
+++ b/shared/nav-loader.js
@@ -4,7 +4,17 @@
     if (!container) return;
     try {
       const response = await fetch('./includes/nav.html');
-      container.innerHTML = await response.text();
+      const markup = await response.text();
+      container.innerHTML = markup;
+
+      const page = document.body?.dataset?.page || '';
+      if (page) {
+        const activeLink = container.querySelector(`.nav-link[data-nav="${page}"]`);
+        if (activeLink) {
+          activeLink.classList.add('active');
+          activeLink.setAttribute('aria-current', 'page');
+        }
+      }
     } catch (err) {
       console.error('Failed to load navigation include', err);
     }

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -26,6 +26,15 @@
   --color-danger: #dc2626;
   --color-success: #16a34a;
   --nav-width: min(280px, 100%);
+  --color-nav-bg: #0b1220;
+  --color-nav-border: #111827;
+  --color-nav-text: #cbd5e1;
+  --color-nav-hover-bg: #111827;
+  --color-nav-active-bg: rgba(16, 185, 129, 0.14);
+  --color-nav-active-border: rgba(16, 185, 129, 0.35);
+  --color-nav-active-text: #ecfdf5;
+  --color-nav-brand: #e5e7eb;
+  --sidebar-width: 240px;
 }
 
 .visually-hidden {
@@ -121,74 +130,60 @@ a:focus {
 }
 
 [data-include='nav'] {
-  position: relative;
-  z-index: 10;
+  display: contents;
 }
 
-.site-nav {
+.sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: var(--sidebar-width);
+  background: var(--color-nav-bg);
+  color: var(--color-nav-text);
+  padding: 24px;
+  border-right: 1px solid var(--color-nav-border);
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-4) clamp(var(--space-4), 2vw + 1rem, var(--space-6));
-  gap: var(--space-4);
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-  backdrop-filter: blur(24px);
-  box-shadow: var(--shadow-xs);
+  flex-direction: column;
+  gap: 20px;
+  z-index: 20;
 }
 
-.site-nav__brand {
+.brand {
   font-weight: 700;
-  font-size: 1.2rem;
-  color: var(--color-heading);
+  font-size: 1.35rem;
 }
 
-.site-nav__links {
+.brand-link {
+  color: var(--color-nav-brand);
+  text-decoration: none;
+}
+
+.nav {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
+  flex-direction: column;
+  gap: 8px;
 }
 
-.site-nav__links a {
-  padding: 0.45rem 0.9rem;
-  border-radius: var(--radius-xs);
-  font-weight: 600;
-  color: var(--color-muted);
-  transition: background 0.3s ease, color 0.3s ease, transform 0.2s ease;
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0.65rem 0.75rem;
+  color: var(--color-nav-text);
+  text-decoration: none;
+  border-radius: 12px;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.site-nav__links a:hover,
-.site-nav__links a:focus {
-  color: var(--color-heading);
-  background: var(--color-primary-soft);
+.nav-link:hover,
+.nav-link:focus-visible {
+  background: var(--color-nav-hover-bg);
+  outline: none;
 }
 
-@media (min-width: 960px) {
-  [data-include='nav'] {
-    min-width: var(--nav-width);
-  }
-
-  .site-nav {
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
-    height: 100vh;
-    position: sticky;
-    top: 0;
-    border-right: 1px solid var(--color-border);
-    border-bottom: none;
-    width: 100%;
-  }
-
-  .site-nav__links {
-    flex-direction: column;
-    width: 100%;
-  }
-
-  .site-nav__links a {
-    width: 100%;
-  }
+.nav-link.active {
+  background: var(--color-nav-active-bg);
+  border: 1px solid var(--color-nav-active-border);
+  color: var(--color-nav-active-text);
 }
 
 .app-main {
@@ -197,6 +192,184 @@ a:focus {
   display: flex;
   align-items: flex-start;
   justify-content: center;
+  margin-left: var(--sidebar-width);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.btn {
+  padding: 0.55rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.btn:hover:not(:disabled) {
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn.primary {
+  background: var(--color-success);
+  border-color: var(--color-success);
+  color: #fff;
+}
+
+.btn.primary:hover:not(:disabled) {
+  background: #15803d;
+}
+
+.btn.ghost {
+  background: var(--color-app-bg-muted);
+}
+
+.btn.ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.chip {
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.chip.active {
+  background: rgba(16, 185, 129, 0.08);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #047857;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.input {
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: #fff;
+}
+
+.panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-xs);
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.toolbar .input {
+  min-width: 200px;
+}
+
+.toolbar .search-field {
+  flex: 1 1 220px;
+  max-width: 420px;
+}
+
+.muted {
+  color: var(--color-muted);
+}
+
+.map {
+  width: 100%;
+  min-height: 420px;
+  height: 62vh;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.map-layout {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: var(--space-4);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 60vh;
+  overflow: auto;
+}
+
+.item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.65rem 0.35rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.item button {
+  margin-left: auto;
+}
+
+@media (max-width: 1024px) {
+  .sidebar {
+    position: sticky;
+    top: 0;
+    inset: auto;
+    width: auto;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--color-nav-border);
+  }
+
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .nav-link {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .app-main {
+    margin-left: 0;
+    padding: var(--space-4);
+  }
+
+  .map-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .map {
+    height: 56vh;
+  }
 }
 
 .container {


### PR DESCRIPTION
## Summary
- redesign the navigation include as a sidebar and highlight the active page via the nav loader
- expand shared styling tokens and responsive helpers for the sidebar, toolbar controls, and map layout
- rebuild the map page UI/logic to share the global shell, improve geolocation snapshots, and keep history editing/export intact
- tag shell pages with data attributes for nav highlighting and adjust the service worker to bypass map/leaflet hosts safely

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e0c71cbc83329e4e51028c66f1df