### PR TITLE
Add Revolut-style theme tokens and root toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+npm-debug.log*

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -1,5 +1,6 @@
 :root {
-  color-scheme: light dark;
+  --theme-mode: dark;
+  color-scheme: var(--theme-mode);
   --font-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -10,31 +11,95 @@
   --space-7: 3rem;
   --radius-xs: 6px;
   --radius-sm: 12px;
-  --radius-lg: 20px;
+  --radius-card: 20px;
+  --radius-lg: var(--radius-card);
+  --shadow-xs: 0 1px 3px rgba(15, 23, 42, 0.32);
+  --shadow-sm: 0 18px 60px rgba(2, 6, 23, 0.32);
+  --shadow-glow: 0 45px 120px rgba(2, 6, 23, 0.45);
+  --glass-blur: 22px;
+  --glass-border-color: rgba(148, 163, 184, 0.32);
+  --glass-border: 1px solid var(--glass-border-color);
+  --glass-surface: rgba(15, 23, 42, 0.58);
+  --color-bg-base: radial-gradient(circle at top, #0f172a 0%, #020617 65%);
+  --color-bg-card: rgba(15, 23, 42, 0.72);
+  --color-bg-card-alt: rgba(15, 23, 42, 0.58);
+  --color-bg-muted: rgba(71, 85, 105, 0.16);
+  --color-border: rgba(148, 163, 184, 0.22);
+  --text-primary: #e2e8f0;
+  --text-heading: #f8fafc;
+  --text-muted: #cbd5f5;
+  --text-inverse: #020617;
+  --color-primary: #60a5fa;
+  --color-primary-soft: rgba(96, 165, 250, 0.22);
+  --color-success: #34d399;
+  --color-warning: #facc15;
+  --color-danger: #f87171;
+  --color-info: #38bdf8;
+  --gradient-movement: linear-gradient(135deg, #1e40af 0%, #38bdf8 100%);
+  --gradient-recovery: linear-gradient(135deg, #0f766e 0%, #2dd4bf 100%);
+  --gradient-focus: linear-gradient(135deg, #7c3aed 0%, #c4b5fd 100%);
+  --gradient-transport: linear-gradient(135deg, #0369a1 0%, #0ea5e9 100%);
+  --gradient-food: linear-gradient(135deg, #be123c 0%, #f97316 100%);
+  --gradient-household: linear-gradient(135deg, #1f2937 0%, #4b5563 100%);
+  --gradient-social: linear-gradient(135deg, #6d28d9 0%, #f472b6 100%);
+  --gradient-other: linear-gradient(135deg, #0f172a 0%, #475569 100%);
+  --nav-width: min(280px, 100%);
+  --color-nav-bg: rgba(2, 6, 23, 0.92);
+  --color-nav-border: rgba(51, 65, 85, 0.65);
+  --color-nav-text: rgba(226, 232, 240, 0.82);
+  --color-nav-hover-bg: rgba(30, 41, 59, 0.82);
+  --color-nav-active-bg: rgba(16, 185, 129, 0.18);
+  --color-nav-active-border: rgba(16, 185, 129, 0.45);
+  --color-nav-active-text: #ecfdf5;
+  --color-nav-brand: #f8fafc;
+  --sidebar-width: 240px;
+  --color-app-bg: var(--color-bg-base);
+  --color-app-bg-muted: var(--color-bg-muted);
+  --color-surface: var(--color-bg-card);
+  --color-surface-alt: var(--color-bg-card-alt);
+  --color-muted: var(--text-muted);
+  --color-text: var(--text-primary);
+  --color-heading: var(--text-heading);
+}
+
+:root[data-theme='light'],
+:root[style*='--theme-mode:light'] {
+  --theme-mode: light;
+  --color-bg-base: linear-gradient(160deg, #eef2ff 0%, #f8fafc 40%, #ffffff 100%);
+  --color-bg-card: rgba(255, 255, 255, 0.9);
+  --color-bg-card-alt: rgba(248, 250, 252, 0.85);
+  --color-bg-muted: rgba(148, 163, 184, 0.1);
+  --color-border: rgba(148, 163, 184, 0.28);
   --shadow-xs: 0 1px 3px rgba(15, 23, 42, 0.1);
   --shadow-sm: 0 12px 34px rgba(15, 23, 42, 0.12);
-  --color-app-bg: linear-gradient(160deg, #eef2ff 0%, #f8fafc 40%, #ffffff 100%);
-  --color-app-bg-muted: rgba(148, 163, 184, 0.08);
-  --color-surface: rgba(255, 255, 255, 0.82);
-  --color-surface-alt: rgba(248, 250, 252, 0.82);
-  --color-border: rgba(148, 163, 184, 0.32);
-  --color-muted: #64748b;
-  --color-text: #0f172a;
-  --color-heading: #111827;
+  --shadow-glow: 0 60px 160px rgba(37, 99, 235, 0.22);
+  --text-primary: #0f172a;
+  --text-heading: #111827;
+  --text-muted: #64748b;
+  --text-inverse: #ffffff;
   --color-primary: #2563eb;
   --color-primary-soft: rgba(37, 99, 235, 0.14);
-  --color-danger: #dc2626;
   --color-success: #16a34a;
-  --nav-width: min(280px, 100%);
-  --color-nav-bg: #0b1220;
-  --color-nav-border: #111827;
-  --color-nav-text: #cbd5e1;
-  --color-nav-hover-bg: #111827;
-  --color-nav-active-bg: rgba(16, 185, 129, 0.14);
-  --color-nav-active-border: rgba(16, 185, 129, 0.35);
-  --color-nav-active-text: #ecfdf5;
-  --color-nav-brand: #e5e7eb;
-  --sidebar-width: 240px;
+  --color-warning: #f97316;
+  --color-danger: #dc2626;
+  --color-info: #0ea5e9;
+  --glass-surface: rgba(255, 255, 255, 0.72);
+  --glass-border-color: rgba(148, 163, 184, 0.35);
+  --color-nav-bg: rgba(15, 23, 42, 0.94);
+  --color-nav-border: rgba(15, 23, 42, 0.65);
+  --color-nav-text: rgba(241, 245, 249, 0.84);
+  --color-nav-hover-bg: rgba(30, 41, 59, 0.86);
+  --color-nav-active-bg: rgba(37, 99, 235, 0.2);
+  --color-nav-active-border: rgba(37, 99, 235, 0.45);
+  --color-nav-active-text: #eff6ff;
+  --color-nav-brand: #111827;
+  --color-app-bg: var(--color-bg-base);
+  --color-app-bg-muted: var(--color-bg-muted);
+  --color-surface: var(--color-bg-card);
+  --color-surface-alt: var(--color-bg-card-alt);
+  --color-muted: var(--text-muted);
+  --color-text: var(--text-primary);
+  --color-heading: var(--text-heading);
 }
 
 .visually-hidden {
@@ -47,38 +112,6 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-app-bg: radial-gradient(circle at top, #0f172a, #020617 65%);
-    --color-app-bg-muted: rgba(71, 85, 105, 0.16);
-    --color-surface: rgba(15, 23, 42, 0.72);
-    --color-surface-alt: rgba(15, 23, 42, 0.58);
-    --color-border: rgba(148, 163, 184, 0.22);
-    --color-muted: #cbd5f5;
-    --color-text: #e2e8f0;
-    --color-heading: #f8fafc;
-    --color-primary: #60a5fa;
-    --color-primary-soft: rgba(96, 165, 250, 0.24);
-    --color-danger: #f87171;
-    --color-success: #34d399;
-  }
-}
-
-[data-theme='dark'] {
-  --color-app-bg: radial-gradient(circle at top, #0f172a, #020617 65%);
-  --color-app-bg-muted: rgba(71, 85, 105, 0.16);
-  --color-surface: rgba(15, 23, 42, 0.72);
-  --color-surface-alt: rgba(15, 23, 42, 0.58);
-  --color-border: rgba(148, 163, 184, 0.22);
-  --color-muted: #cbd5f5;
-  --color-text: #e2e8f0;
-  --color-heading: #f8fafc;
-  --color-primary: #60a5fa;
-  --color-primary-soft: rgba(96, 165, 250, 0.24);
-  --color-danger: #f87171;
-  --color-success: #34d399;
 }
 
 html {

--- a/shared/tokens.json
+++ b/shared/tokens.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "meta": {
+    "name": "Health2099 tokens",
+    "version": "1.0.0",
+    "defaultTheme": "dark"
+  },
+  "radii": {
+    "xs": 6,
+    "sm": 12,
+    "card": 20
+  },
+  "shadows": {
+    "xs": "0 1px 3px rgba(15, 23, 42, 0.32)",
+    "sm": "0 18px 60px rgba(2, 6, 23, 0.32)",
+    "glow": "0 45px 120px rgba(2, 6, 23, 0.45)"
+  },
+  "glass": {
+    "blur": 22,
+    "borderColor": "rgba(148, 163, 184, 0.32)",
+    "surface": {
+      "dark": "rgba(15, 23, 42, 0.58)",
+      "light": "rgba(255, 255, 255, 0.72)"
+    }
+  },
+  "colors": {
+    "bg": {
+      "base": {
+        "dark": "radial-gradient(circle at top, #0f172a 0%, #020617 65%)",
+        "light": "linear-gradient(160deg, #eef2ff 0%, #f8fafc 40%, #ffffff 100%)"
+      },
+      "card": {
+        "dark": "rgba(15, 23, 42, 0.72)",
+        "light": "rgba(255, 255, 255, 0.9)"
+      },
+      "cardAlt": {
+        "dark": "rgba(15, 23, 42, 0.58)",
+        "light": "rgba(248, 250, 252, 0.85)"
+      },
+      "muted": {
+        "dark": "rgba(71, 85, 105, 0.16)",
+        "light": "rgba(148, 163, 184, 0.1)"
+      }
+    },
+    "text": {
+      "primary": {
+        "dark": "#e2e8f0",
+        "light": "#0f172a"
+      },
+      "heading": {
+        "dark": "#f8fafc",
+        "light": "#111827"
+      },
+      "muted": {
+        "dark": "#cbd5f5",
+        "light": "#64748b"
+      }
+    },
+    "semantic": {
+      "primary": {
+        "dark": "#60a5fa",
+        "light": "#2563eb"
+      },
+      "success": {
+        "dark": "#34d399",
+        "light": "#16a34a"
+      },
+      "warning": {
+        "dark": "#facc15",
+        "light": "#f97316"
+      },
+      "danger": {
+        "dark": "#f87171",
+        "light": "#dc2626"
+      },
+      "info": {
+        "dark": "#38bdf8",
+        "light": "#0ea5e9"
+      }
+    }
+  },
+  "gradients": {
+    "movement": "linear-gradient(135deg, #1e40af 0%, #38bdf8 100%)",
+    "recovery": "linear-gradient(135deg, #0f766e 0%, #2dd4bf 100%)",
+    "focus": "linear-gradient(135deg, #7c3aed 0%, #c4b5fd 100%)",
+    "transport": "linear-gradient(135deg, #0369a1 0%, #0ea5e9 100%)",
+    "food": "linear-gradient(135deg, #be123c 0%, #f97316 100%)",
+    "household": "linear-gradient(135deg, #1f2937 0%, #4b5563 100%)",
+    "social": "linear-gradient(135deg, #6d28d9 0%, #f472b6 100%)",
+    "other": "linear-gradient(135deg, #0f172a 0%, #475569 100%)"
+  }
+}


### PR DESCRIPTION
## Summary
- define Health 2099 design tokens, gradients, and semantic colors in a shared JSON manifest
- refactor global CSS variables to adopt the new token names, premium glass shadows, and dark-first theming
- ensure light theme overrides are driven from the root variable and ignore build artefacts via .gitignore

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e5e7835c588332b7c73b2c815c265b