### PR TITLE
feat: add health cabinet dashboard

### DIFF
--- a/HealthCabinet.html
+++ b/HealthCabinet.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Health cabinet</title>
+    <meta name="theme-color" content="#2563eb" />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./shared/styles.css" />
+  </head>
+  <body class="app-shell" data-page="health">
+    <div data-include="nav"></div>
+    <main class="app-main">
+      <div class="container flow health-dashboard" data-health-dashboard>
+        <header class="page-header">
+          <span class="page-header__eyebrow">Health cabinet</span>
+          <h1>Dashboard overview</h1>
+          <p>Live snapshot of wellness metrics powered by personal diary data and wearables.</p>
+        </header>
+
+        <section class="health-dashboard__top" data-section="top"></section>
+        <section class="health-dashboard__kpi" data-section="kpi"></section>
+        <section class="health-dashboard__rings" data-section="rings"></section>
+        <section class="health-dashboard__facts" data-section="facts"></section>
+        <section class="health-dashboard__notes" data-section="notes"></section>
+      </div>
+    </main>
+
+    <script src="./shared/storage.js"></script>
+    <script src="./shared/nav-loader.js"></script>
+    <script type="module" src="./health/health-cabinet-page.js"></script>
+  </body>
+</html>

--- a/components/health/DeviceStatus.js
+++ b/components/health/DeviceStatus.js
@@ -1,0 +1,56 @@
+const INPUT_LABELS = {
+  manual: 'Manual',
+  auto: 'Auto',
+};
+
+function formatBattery(value) {
+  if (!Number.isFinite(value)) return '—';
+  return `${Math.max(0, Math.min(100, Math.round(value)))}%`;
+}
+
+export function createDeviceStatus() {
+  const section = document.createElement('section');
+  section.className = 'card device-status';
+  section.innerHTML = `
+    <header class="device-status__header">
+      <h2>Device status</h2>
+    </header>
+    <div class="device-status__badges">
+      <span class="badge" data-online>Online</span>
+      <span class="badge" data-battery>Battery</span>
+      <span class="badge" data-input>●○○ Manual</span>
+    </div>
+  `;
+
+  function update(snapshot) {
+    if (!snapshot) return;
+    const online = section.querySelector('[data-online]');
+    const battery = section.querySelector('[data-battery]');
+    const input = section.querySelector('[data-input]');
+
+    if (online) {
+      if (snapshot.online) {
+        online.textContent = 'Online';
+        online.dataset.status = 'online';
+      } else {
+        const minutes = Number.isFinite(snapshot.offline_min) ? Math.max(1, Math.round(snapshot.offline_min)) : 0;
+        online.textContent = minutes ? `Offline ${minutes}+ min` : 'Offline';
+        online.dataset.status = 'offline';
+      }
+    }
+
+    if (battery) {
+      battery.textContent = `Battery: ${formatBattery(snapshot.battery)}`;
+    }
+
+    if (input) {
+      const label = INPUT_LABELS[snapshot.input] || 'Manual';
+      input.textContent = `●○○ ${label}`;
+      input.dataset.mode = snapshot.input || 'manual';
+    }
+  }
+
+  return { element: section, update };
+}
+
+export default createDeviceStatus;

--- a/components/health/DualGauge.js
+++ b/components/health/DualGauge.js
@@ -1,0 +1,105 @@
+const ZONES = [
+  { max: 39, className: 'danger' },
+  { max: 59, className: 'warning' },
+  { max: 79, className: 'success' },
+  { max: 100, className: 'primary' },
+];
+
+function resolveZone(value) {
+  const num = Number.isFinite(value) ? value : 0;
+  return ZONES.find((zone) => num <= zone.max) || ZONES[ZONES.length - 1];
+}
+
+function formatDelta(value) {
+  if (!Number.isFinite(value) || value === 0) return '0';
+  const prefix = value > 0 ? '+' : '';
+  return `${prefix}${value}`;
+}
+
+function setRing(el, value) {
+  if (!el) return;
+  const clamped = Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
+  el.style.setProperty('--progress', clamped);
+  const zone = resolveZone(clamped);
+  el.dataset.zone = zone.className;
+}
+
+function updateCard(card, { label, value, delta }) {
+  if (!card) return;
+  const valueEl = card.querySelector('[data-value]');
+  const deltaEl = card.querySelector('[data-delta]');
+  const gaugeEl = card.querySelector('.dual-gauge__ring');
+  const labelEl = card.querySelector('[data-label]');
+  if (labelEl) labelEl.textContent = label;
+  if (valueEl) valueEl.textContent = Number.isFinite(value) ? Math.round(value).toString() : '—';
+  if (deltaEl) {
+    deltaEl.textContent = `Δ 15m · ${formatDelta(delta)}`;
+    deltaEl.dataset.trend = !Number.isFinite(delta)
+      ? 'neutral'
+      : delta > 0
+        ? 'up'
+        : delta < 0
+          ? 'down'
+          : 'neutral';
+  }
+  setRing(gaugeEl, value);
+}
+
+function updateConfidence(container, confidence) {
+  if (!container) return;
+  const confidenceEl = container.querySelector('[data-confidence]');
+  if (!confidenceEl) return;
+  const value = confidence === 'auto' ? 'Auto' : confidence === 'timeout' ? 'Timeout' : 'Manual';
+  confidenceEl.textContent = `●●● ${value}`;
+  confidenceEl.dataset.mode = confidence || 'manual';
+}
+
+export function createDualGauge() {
+  const section = document.createElement('section');
+  section.className = 'card dual-gauge';
+  section.innerHTML = `
+    <div class="dual-gauge__cards">
+      <div class="dual-gauge__card" data-kind="energy">
+        <div class="dual-gauge__ring" aria-hidden="true"><span class="dual-gauge__value" data-value>0</span></div>
+        <div class="dual-gauge__content">
+          <span class="dual-gauge__label" data-label>Energy</span>
+          <span class="dual-gauge__delta" data-delta data-caption>Δ 15m · 0</span>
+        </div>
+      </div>
+      <div class="dual-gauge__card" data-kind="srv">
+        <div class="dual-gauge__ring" aria-hidden="true"><span class="dual-gauge__value" data-value>0</span></div>
+        <div class="dual-gauge__content">
+          <span class="dual-gauge__label" data-label>SRV</span>
+          <span class="dual-gauge__delta" data-delta data-caption>Δ 15m · 0</span>
+        </div>
+      </div>
+    </div>
+    <footer class="dual-gauge__footer">
+      <span class="badge" data-confidence data-mode="manual">●●● Manual</span>
+    </footer>
+  `;
+
+  const cards = {
+    energy: section.querySelector('[data-kind="energy"]'),
+    srv: section.querySelector('[data-kind="srv"]'),
+  };
+
+  function update(snapshot) {
+    if (!snapshot) return;
+    updateCard(cards.energy, {
+      label: 'Energy',
+      value: snapshot.energy,
+      delta: snapshot.delta15m ? snapshot.delta15m.energy : 0,
+    });
+    updateCard(cards.srv, {
+      label: 'SRV',
+      value: snapshot.srv,
+      delta: snapshot.delta15m ? snapshot.delta15m.srv : 0,
+    });
+    updateConfidence(section, snapshot.confidence);
+  }
+
+  return { element: section, update };
+}
+
+export default createDualGauge;

--- a/components/health/FactsRow.js
+++ b/components/health/FactsRow.js
@@ -1,0 +1,70 @@
+import { badgeRules } from '../../health/dashboard-engine.js';
+
+const CHIP_ITEMS = [
+  { key: 'alcohol_yday', label: 'Alcohol (yesterday)' },
+  { key: 'symptoms', label: 'Illness symptoms' },
+  { key: 'energy_adj', label: 'Energy adj.' },
+  { key: 'late_meal', label: 'Late meal' },
+];
+
+function formatChipValue(key, value) {
+  if (key === 'energy_adj') {
+    if (!Number.isFinite(value)) return '0';
+    const prefix = value > 0 ? '+' : '';
+    return `${prefix}${value}`;
+  }
+  if (value == null) return '—';
+  return value ? 'Yes' : 'No';
+}
+
+export function createFactsRow() {
+  const section = document.createElement('section');
+  section.className = 'card facts-row';
+  section.innerHTML = `
+    <div class="facts-row__primary">
+      <article class="facts-row__sleep">
+        <h3>Sleep</h3>
+        <p class="facts-row__sleep-value" data-sleep-value>—</p>
+        <span class="badge" data-sleep-badge>—</span>
+      </article>
+      <div class="facts-row__chips" data-chips></div>
+    </div>
+  `;
+
+  const chipsContainer = section.querySelector('[data-chips]');
+  if (chipsContainer) {
+    CHIP_ITEMS.forEach((item) => {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.dataset.key = item.key;
+      chip.innerHTML = `<span class="chip__label">${item.label}</span><span class="chip__value" data-value>—</span>`;
+      chipsContainer.appendChild(chip);
+    });
+  }
+
+  function update(snapshot) {
+    const sleepValueEl = section.querySelector('[data-sleep-value]');
+    const sleepBadgeEl = section.querySelector('[data-sleep-badge]');
+    const hours = snapshot && Number.isFinite(snapshot.sleep_h) ? snapshot.sleep_h : null;
+    if (sleepValueEl) {
+      sleepValueEl.textContent = hours == null ? '—' : `${hours.toFixed(1)} h`;
+    }
+    if (sleepBadgeEl) {
+      sleepBadgeEl.textContent = badgeRules.sleep(hours);
+    }
+
+    CHIP_ITEMS.forEach((item) => {
+      const chip = chipsContainer ? chipsContainer.querySelector(`[data-key="${item.key}"]`) : null;
+      if (!chip) return;
+      const valueEl = chip.querySelector('[data-value]');
+      const raw = snapshot ? snapshot[item.key] : null;
+      if (valueEl) {
+        valueEl.textContent = formatChipValue(item.key, raw);
+      }
+    });
+  }
+
+  return { element: section, update };
+}
+
+export default createFactsRow;

--- a/components/health/KpiGrid.js
+++ b/components/health/KpiGrid.js
@@ -1,0 +1,69 @@
+import { badgeRules } from '../../health/dashboard-engine.js';
+
+const KPI_LABELS = [
+  { key: 'wellbeing7', title: 'Wellbeing score (week)' },
+  { key: 'cardio', title: 'Cardio-vascular' },
+  { key: 'risk', title: 'Risk of pathology' },
+  { key: 'arrhythmia', title: 'Arrhythmias' },
+];
+
+function resolveBadge(key, badge, value) {
+  if (badge) return badge;
+  switch (key) {
+    case 'wellbeing7':
+      return badgeRules.wellbeing(value);
+    case 'cardio':
+      return badgeRules.cardio(value);
+    case 'risk':
+      return badgeRules.risk(value);
+    case 'arrhythmia':
+      return badgeRules.arrhythmia(value);
+    default:
+      return '—';
+  }
+}
+
+export function createKpiGrid() {
+  const section = document.createElement('section');
+  section.className = 'card kpi-grid';
+  const list = document.createElement('div');
+  list.className = 'kpi-grid__items';
+
+  KPI_LABELS.forEach((item) => {
+    const card = document.createElement('article');
+    card.className = 'kpi-grid__card';
+    card.dataset.key = item.key;
+    card.innerHTML = `
+      <header class="kpi-grid__header">
+        <h3>${item.title}</h3>
+        <span class="badge" data-badge>—</span>
+      </header>
+      <p class="kpi-grid__value" data-value>0</p>
+    `;
+    list.appendChild(card);
+  });
+
+  section.appendChild(list);
+
+  function update(snapshot) {
+    KPI_LABELS.forEach((item) => {
+      const card = list.querySelector(`[data-key="${item.key}"]`);
+      if (!card) return;
+      const valueEl = card.querySelector('[data-value]');
+      const badgeEl = card.querySelector('[data-badge]');
+      const entry = snapshot ? snapshot[item.key] : null;
+      const value = entry && Number.isFinite(entry.value) ? Math.round(entry.value) : null;
+      if (valueEl) {
+        valueEl.textContent = value == null ? '—' : `${value}`;
+      }
+      if (badgeEl) {
+        const text = resolveBadge(item.key, entry?.badge, value ?? 0);
+        badgeEl.textContent = text;
+      }
+    });
+  }
+
+  return { element: section, update };
+}
+
+export default createKpiGrid;

--- a/components/health/NotesCard.js
+++ b/components/health/NotesCard.js
@@ -1,0 +1,72 @@
+import { dashboard } from '../../stores/dashboard.js';
+
+const SAVE_DELAY = 600;
+
+export function createNotesCard() {
+  const section = document.createElement('section');
+  section.className = 'card notes-card';
+  section.innerHTML = `
+    <header class="notes-card__header">
+      <h2>Notes</h2>
+      <p>Recommendations will appear later (based on Energy / SRV / Stress).</p>
+    </header>
+    <label class="notes-card__field">
+      <span class="visually-hidden">Notes</span>
+      <textarea rows="4" data-notes placeholder="Add personal observations..." spellcheck="false"></textarea>
+      <span class="notes-card__status" aria-live="polite" data-status></span>
+    </label>
+  `;
+
+  const textarea = section.querySelector('[data-notes]');
+  const statusEl = section.querySelector('[data-status]');
+  let saveTimer = null;
+  let lastValue = '';
+  let isFocused = false;
+
+  function scheduleSave(value) {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+    }
+    if (statusEl) {
+      statusEl.textContent = 'Saving…';
+    }
+    saveTimer = setTimeout(() => {
+      dashboard.updateNotes(value);
+      if (statusEl) {
+        statusEl.textContent = 'Saved';
+      }
+      saveTimer = null;
+    }, SAVE_DELAY);
+  }
+
+  if (textarea) {
+    textarea.addEventListener('input', (event) => {
+      const value = event.target.value;
+      lastValue = value;
+      scheduleSave(value);
+    });
+    textarea.addEventListener('focus', () => {
+      isFocused = true;
+    });
+    textarea.addEventListener('blur', () => {
+      isFocused = false;
+      if (saveTimer || !statusEl) return;
+      statusEl.textContent = '';
+    });
+  }
+
+  function update(notes) {
+    const nextValue = typeof notes === 'string' ? notes : '';
+    if (textarea && !isFocused) {
+      textarea.value = nextValue;
+      lastValue = nextValue;
+    }
+    if (!nextValue && statusEl) {
+      statusEl.textContent = '';
+    }
+  }
+
+  return { element: section, update };
+}
+
+export default createNotesCard;

--- a/components/health/RingRow.js
+++ b/components/health/RingRow.js
@@ -1,0 +1,74 @@
+import { badgeRules } from '../../health/dashboard-engine.js';
+
+const RING_ITEMS = [
+  { key: 'stress', title: 'Stress' },
+  { key: 'burnout', title: 'Burnout' },
+  { key: 'fatigue', title: 'Fatigue' },
+];
+
+export function createRingRow() {
+  const section = document.createElement('section');
+  section.className = 'card ring-row';
+  const ringsContainer = document.createElement('div');
+  ringsContainer.className = 'ring-row__rings';
+
+  RING_ITEMS.forEach((item) => {
+    const card = document.createElement('article');
+    card.className = 'ring-row__card';
+    card.dataset.key = item.key;
+    card.innerHTML = `
+      <div class="ring" aria-hidden="true"></div>
+      <div class="ring__content">
+        <span class="ring__label">${item.title}</span>
+        <span class="ring__value" data-value>0%</span>
+      </div>
+    `;
+    ringsContainer.appendChild(card);
+  });
+
+  const heartCard = document.createElement('article');
+  heartCard.className = 'ring-row__card ring-row__card--heart';
+  heartCard.innerHTML = `
+    <div class="ring__content">
+      <span class="ring__label">Heart age</span>
+      <span class="ring__value" data-heart-value>0</span>
+      <span class="badge" data-heart-badge>—</span>
+    </div>
+  `;
+
+  section.appendChild(ringsContainer);
+  section.appendChild(heartCard);
+
+  function update(snapshot) {
+    RING_ITEMS.forEach((item) => {
+      const card = ringsContainer.querySelector(`[data-key="${item.key}"]`);
+      if (!card) return;
+      const value = snapshot && Number.isFinite(snapshot[item.key]) ? Math.max(0, Math.min(100, Math.round(snapshot[item.key]))) : null;
+      const valueEl = card.querySelector('[data-value]');
+      const ring = card.querySelector('.ring');
+      if (valueEl) {
+        valueEl.textContent = value == null ? '—' : `${value}%`;
+      }
+      if (ring) {
+        const percent = value == null ? 0 : value;
+        ring.style.setProperty('--progress', percent);
+      }
+    });
+
+    const heartValueEl = heartCard.querySelector('[data-heart-value]');
+    const heartBadgeEl = heartCard.querySelector('[data-heart-badge]');
+    const heart = snapshot?.heartAge;
+    const heartValue = heart && Number.isFinite(heart.value) ? Math.round(heart.value) : null;
+    if (heartValueEl) {
+      heartValueEl.textContent = heartValue == null ? '—' : `${heartValue}`;
+    }
+    if (heartBadgeEl) {
+      const badge = heart?.badge || (heartValue == null ? '—' : badgeRules.cardio(heartValue));
+      heartBadgeEl.textContent = badge;
+    }
+  }
+
+  return { element: section, update };
+}
+
+export default createRingRow;

--- a/health/dashboard-engine.js
+++ b/health/dashboard-engine.js
@@ -1,0 +1,149 @@
+import { dashboard } from '../stores/dashboard.js';
+
+const clamp = (value, min = 0, max = 100) => {
+  const num = Number.isFinite(value) ? value : 0;
+  if (num < min) return min;
+  if (num > max) return max;
+  return Math.round(num);
+};
+
+const badgeRules = {
+  wellbeing(value) {
+    if (value >= 85) return 'Excellent';
+    if (value >= 75) return 'Good';
+    if (value >= 60) return 'Normal';
+    return 'Low';
+  },
+  cardio(value) {
+    if (value >= 85) return 'Excellent';
+    if (value >= 70) return 'Within acceptable';
+    if (value >= 50) return 'Needs attention';
+    return 'Low';
+  },
+  risk(value) {
+    if (value <= 35) return 'Low';
+    if (value <= 65) return 'System acceptable';
+    return 'Elevated';
+  },
+  arrhythmia(value) {
+    if (value <= 10) return 'Within normal';
+    if (value <= 25) return 'Watch';
+    return 'Elevated';
+  },
+  sleep(hours) {
+    if (hours == null) return '—';
+    if (hours >= 7 && hours <= 9) return 'Within normal';
+    if (hours < 7) return 'Short';
+    return 'Long';
+  },
+};
+
+function computePlaceholderSnapshot() {
+  const base = dashboard.fixture;
+  const current = dashboard.getSnapshot();
+
+  const gauges = {
+    energy: clamp(current?.gauges?.energy ?? base.gauges.energy),
+    srv: clamp(current?.gauges?.srv ?? base.gauges.srv),
+    delta15m: {
+      energy: Number.isFinite(current?.gauges?.delta15m?.energy)
+        ? Math.round(current.gauges.delta15m.energy)
+        : base.gauges.delta15m.energy,
+      srv: Number.isFinite(current?.gauges?.delta15m?.srv)
+        ? Math.round(current.gauges.delta15m.srv)
+        : base.gauges.delta15m.srv,
+    },
+    confidence: current?.gauges?.confidence || base.gauges.confidence,
+  };
+
+  const device = {
+    online: current?.device?.online ?? base.device.online,
+    offline_min: Number.isFinite(current?.device?.offline_min)
+      ? Math.max(0, Math.round(current.device.offline_min))
+      : base.device.offline_min,
+    battery: clamp(current?.device?.battery ?? base.device.battery),
+    input: current?.device?.input || base.device.input,
+  };
+
+  const wellbeingValue = clamp(current?.kpi?.wellbeing7?.value ?? base.kpi.wellbeing7.value);
+  const cardioValue = clamp(current?.kpi?.cardio?.value ?? base.kpi.cardio.value);
+  const riskValue = clamp(current?.kpi?.risk?.value ?? base.kpi.risk.value);
+  const arrhythmiaValue = clamp(current?.kpi?.arrhythmia?.value ?? base.kpi.arrhythmia.value);
+
+  const rings = {
+    stress: clamp(current?.rings?.stress ?? base.rings.stress),
+    burnout: clamp(current?.rings?.burnout ?? base.rings.burnout),
+    fatigue: clamp(current?.rings?.fatigue ?? base.rings.fatigue),
+    heartAge: {
+      value: clamp(current?.rings?.heartAge?.value ?? base.rings.heartAge.value, 0, 120),
+      badge: current?.rings?.heartAge?.badge || base.rings.heartAge.badge,
+    },
+  };
+
+  const sleepHours = Number.isFinite(current?.facts?.sleep_h) ? current.facts.sleep_h : base.facts.sleep_h;
+
+  const facts = {
+    sleep_h: sleepHours,
+    alcohol_yday:
+      current?.facts?.alcohol_yday == null ? base.facts.alcohol_yday : current.facts.alcohol_yday,
+    symptoms: current?.facts?.symptoms == null ? base.facts.symptoms : current.facts.symptoms,
+    energy_adj: Number.isFinite(current?.facts?.energy_adj)
+      ? Math.round(current.facts.energy_adj)
+      : base.facts.energy_adj,
+    late_meal: current?.facts?.late_meal == null ? base.facts.late_meal : current.facts.late_meal,
+  };
+
+  return {
+    gauges,
+    device,
+    kpi: {
+      wellbeing7: { value: wellbeingValue, badge: badgeRules.wellbeing(wellbeingValue) },
+      cardio: { value: cardioValue, badge: badgeRules.cardio(cardioValue) },
+      risk: { value: riskValue, badge: badgeRules.risk(riskValue) },
+      arrhythmia: { value: arrhythmiaValue, badge: badgeRules.arrhythmia(arrhythmiaValue) },
+    },
+    rings,
+    facts: {
+      ...facts,
+    },
+    notes: typeof current?.notes === 'string' ? current.notes : base.notes,
+  };
+}
+
+export function recomputeDashboard(now = new Date()) {
+  void now;
+  const snapshot = computePlaceholderSnapshot();
+  dashboard.set(snapshot);
+  return snapshot;
+}
+
+export function bootstrapDashboardPage() {
+  recomputeDashboard(new Date());
+  window.addEventListener('focus', handleFocus);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  window.addEventListener('health:changed', handleExternalChange);
+  return () => {
+    window.removeEventListener('focus', handleFocus);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    window.removeEventListener('health:changed', handleExternalChange);
+  };
+}
+
+function handleFocus() {
+  recomputeDashboard(new Date());
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState === 'visible') {
+    recomputeDashboard(new Date());
+  }
+}
+
+function handleExternalChange(event) {
+  const target = event && event.detail ? event.detail.target : undefined;
+  if (!target || target === 'events' || target === 'settings') {
+    recomputeDashboard(new Date());
+  }
+}
+
+export { badgeRules };

--- a/health/health-cabinet-page.js
+++ b/health/health-cabinet-page.js
@@ -1,0 +1,90 @@
+import { dashboard } from '../stores/dashboard.js';
+import { bootstrapDashboardPage } from './dashboard-engine.js';
+import { createDualGauge } from '../components/health/DualGauge.js';
+import { createDeviceStatus } from '../components/health/DeviceStatus.js';
+import { createKpiGrid } from '../components/health/KpiGrid.js';
+import { createRingRow } from '../components/health/RingRow.js';
+import { createFactsRow } from '../components/health/FactsRow.js';
+import { createNotesCard } from '../components/health/NotesCard.js';
+
+const subscribers = [];
+
+function mountComponents(root) {
+  const topRow = root.querySelector('[data-section="top"]');
+  const kpiRow = root.querySelector('[data-section="kpi"]');
+  const ringRowContainer = root.querySelector('[data-section="rings"]');
+  const factsRowContainer = root.querySelector('[data-section="facts"]');
+  const notesContainer = root.querySelector('[data-section="notes"]');
+
+  const dualGauge = createDualGauge();
+  const deviceStatus = createDeviceStatus();
+  const kpiGrid = createKpiGrid();
+  const ringRow = createRingRow();
+  const factsRow = createFactsRow();
+  const notesCard = createNotesCard();
+
+  if (topRow) {
+    topRow.appendChild(dualGauge.element);
+    topRow.appendChild(deviceStatus.element);
+  }
+  if (kpiRow) {
+    kpiRow.appendChild(kpiGrid.element);
+  }
+  if (ringRowContainer) {
+    ringRowContainer.appendChild(ringRow.element);
+  }
+  if (factsRowContainer) {
+    factsRowContainer.appendChild(factsRow.element);
+  }
+  if (notesContainer) {
+    notesContainer.appendChild(notesCard.element);
+  }
+
+  function render(snapshot) {
+    const gauges = dashboard.selectors.gauges(snapshot);
+    const device = dashboard.selectors.device(snapshot);
+    const kpi = dashboard.selectors.kpi(snapshot);
+    const rings = dashboard.selectors.rings(snapshot);
+    const facts = dashboard.selectors.facts(snapshot);
+    const notes = dashboard.selectors.notes(snapshot);
+
+    dualGauge.update(gauges);
+    deviceStatus.update(device);
+    kpiGrid.update(kpi);
+    ringRow.update(rings);
+    factsRow.update(facts);
+    notesCard.update(notes);
+  }
+
+  render(dashboard.getSnapshot());
+  const unsubscribe = dashboard.subscribe(render);
+  subscribers.push(unsubscribe);
+
+  const teardown = bootstrapDashboardPage();
+  subscribers.push(teardown);
+}
+
+function init() {
+  const root = document.querySelector('[data-health-dashboard]');
+  if (!root) return;
+  mountComponents(root);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+
+window.addEventListener('beforeunload', () => {
+  while (subscribers.length) {
+    const fn = subscribers.pop();
+    if (typeof fn === 'function') {
+      try {
+        fn();
+      } catch (err) {
+        console.error('[health] Failed to dispose listener', err);
+      }
+    }
+  }
+});

--- a/includes/nav.html
+++ b/includes/nav.html
@@ -5,6 +5,7 @@
 
   <nav class="nav" aria-label="Primary">
     <a href="Summary.html" data-nav="summary" class="nav-link"><span>Summary</span></a>
+    <a href="HealthCabinet.html" data-nav="health" class="nav-link"><span>Health cabinet</span></a>
     <a href="DiaryPlus.html" data-nav="diary" class="nav-link"><span>Diary</span></a>
     <a href="Map.html" data-nav="map" class="nav-link"><span>Map</span></a>
   </nav>

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -501,6 +501,389 @@ textarea {
   color: var(--color-muted);
 }
 
+.health-dashboard {
+  display: grid;
+  gap: var(--space-4);
+  padding-bottom: var(--space-6);
+}
+
+.health-dashboard__top {
+  display: grid;
+  gap: var(--space-4);
+}
+
+@media (min-width: 960px) {
+  .health-dashboard__top {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  }
+}
+
+.health-dashboard__kpi,
+.health-dashboard__rings,
+.health-dashboard__facts,
+.health-dashboard__notes {
+  display: contents;
+}
+
+.dual-gauge {
+  padding: var(--space-4) var(--space-4) var(--space-3);
+}
+
+.dual-gauge__cards {
+  display: grid;
+  gap: var(--space-4);
+}
+
+@media (min-width: 640px) {
+  .dual-gauge__cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.dual-gauge__card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.dual-gauge__ring {
+  --progress: 0;
+  --gauge-color: var(--color-primary);
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: conic-gradient(var(--gauge-color) calc(var(--progress) * 1%), rgba(148, 163, 184, 0.2) 0);
+  position: relative;
+  transition: background 0.22s ease;
+  display: grid;
+  place-items: center;
+}
+
+.dual-gauge__ring::after {
+  content: '';
+  position: absolute;
+  inset: 18px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+  z-index: 0;
+}
+
+.dual-gauge__ring[data-zone='danger'] {
+  --gauge-color: var(--color-danger);
+}
+
+.dual-gauge__ring[data-zone='warning'] {
+  --gauge-color: var(--color-warning);
+}
+
+.dual-gauge__ring[data-zone='success'] {
+  --gauge-color: var(--color-success);
+}
+
+.dual-gauge__content {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.dual-gauge__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-muted);
+}
+
+.dual-gauge__value {
+  font-size: clamp(1.8rem, 2.4vw + 1rem, 2.8rem);
+  font-weight: 700;
+  color: var(--color-heading);
+  font-variant-numeric: tabular-nums;
+  position: relative;
+  z-index: 1;
+}
+
+.dual-gauge__delta {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dual-gauge__delta[data-trend='up'] {
+  color: var(--color-success);
+}
+
+.dual-gauge__delta[data-trend='down'] {
+  color: var(--color-danger);
+}
+
+.dual-gauge__footer {
+  margin-top: var(--space-3);
+}
+
+.dual-gauge [data-confidence][data-mode='auto'] {
+  background: rgba(14, 165, 233, 0.18);
+  color: var(--color-info);
+}
+
+.dual-gauge [data-confidence][data-mode='timeout'] {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--color-danger);
+}
+
+.device-status {
+  align-content: start;
+  gap: var(--space-3);
+}
+
+.device-status__header h2 {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+}
+
+.device-status__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.device-status [data-online][data-status='offline'] {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--color-danger);
+}
+
+.device-status [data-input][data-mode='auto'] {
+  background: rgba(52, 211, 153, 0.18);
+  color: var(--color-success);
+}
+
+.kpi-grid__items {
+  display: grid;
+  gap: var(--space-4);
+}
+
+@media (min-width: 760px) {
+  .kpi-grid__items {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .kpi-grid__items {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.kpi-grid__card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.kpi-grid__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.kpi-grid__header h3 {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+}
+
+.kpi-grid__value {
+  font-size: clamp(1.8rem, 1.6vw + 1.4rem, 2.6rem);
+  font-weight: 700;
+  color: var(--color-heading);
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.ring-row {
+  gap: var(--space-4);
+}
+
+.ring-row__rings {
+  display: grid;
+  gap: var(--space-4);
+}
+
+@media (min-width: 760px) {
+  .ring-row__rings {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.ring-row__card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  justify-items: center;
+  gap: var(--space-3);
+}
+
+.ring-row__card--heart {
+  align-self: stretch;
+}
+
+.ring {
+  --progress: 0;
+  --ring-color: var(--color-primary);
+  width: 160px;
+  height: 80px;
+  position: relative;
+  overflow: hidden;
+}
+
+.ring::before {
+  content: '';
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  left: 0;
+  bottom: 0;
+  border-radius: 50%;
+  background: conic-gradient(var(--ring-color) calc(var(--progress) * 1%), rgba(148, 163, 184, 0.18) 0);
+  transform: rotate(180deg);
+  transition: background 0.3s ease;
+}
+
+.ring::after {
+  content: '';
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  left: 20px;
+  bottom: -20px;
+  border-radius: 50%;
+  background: var(--color-surface);
+}
+
+.ring__content {
+  display: grid;
+  gap: var(--space-1);
+  justify-items: center;
+}
+
+.ring__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.ring__value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-heading);
+}
+
+.facts-row {
+  gap: var(--space-4);
+}
+
+.facts-row__primary {
+  display: grid;
+  gap: var(--space-4);
+}
+
+@media (min-width: 760px) {
+  .facts-row__primary {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+    align-items: start;
+  }
+}
+
+.facts-row__sleep {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.facts-row__sleep-value {
+  margin: 0;
+  font-size: clamp(1.4rem, 1.1vw + 1rem, 2rem);
+  font-weight: 600;
+  color: var(--color-heading);
+  font-variant-numeric: tabular-nums;
+}
+
+.facts-row__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.chip__value {
+  font-weight: 600;
+  color: var(--color-heading);
+  font-variant-numeric: tabular-nums;
+}
+
+.notes-card {
+  gap: var(--space-3);
+}
+
+.notes-card__header h2 {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+}
+
+.notes-card__header p {
+  color: var(--color-muted);
+  margin-top: var(--space-1);
+}
+
+.notes-card__field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.notes-card textarea {
+  width: 100%;
+  min-height: 140px;
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
+  font: inherit;
+  resize: vertical;
+  font-variant-numeric: tabular-nums;
+}
+
+.notes-card textarea:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.notes-card__status {
+  min-height: 1rem;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
 .table-wrapper {
   overflow-x: auto;
   border-radius: var(--radius-lg);

--- a/stores/dashboard.js
+++ b/stores/dashboard.js
@@ -1,0 +1,123 @@
+const DASHBOARD_NOTES_KEY = 'health_dashboard_notes_v1';
+
+const dashboardFixture = {
+  gauges: { energy: 70, srv: 53, delta15m: { energy: 4, srv: -1 }, confidence: 'manual' },
+  device: { online: false, offline_min: 10, battery: 82, input: 'manual' },
+  kpi: {
+    wellbeing7: { value: 78, badge: 'Normal' },
+    cardio: { value: 89, badge: 'Within acceptable' },
+    risk: { value: 65, badge: 'System acceptable' },
+    arrhythmia: { value: 10, badge: 'Within normal' },
+  },
+  rings: {
+    stress: 30,
+    burnout: 21,
+    fatigue: 41,
+    heartAge: { value: 50, badge: 'Older than biological (+1)' },
+  },
+  facts: {
+    sleep_h: 7.5,
+    alcohol_yday: false,
+    symptoms: false,
+    energy_adj: 10,
+    late_meal: false,
+  },
+  notes: 'Recommendations will appear later (based on Energy / SRV / Stress).',
+};
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function readStoredNotes() {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const value = localStorage.getItem(DASHBOARD_NOTES_KEY);
+    return value == null ? null : value;
+  } catch (err) {
+    console.warn('[dashboard] Failed to read stored notes', err);
+    return null;
+  }
+}
+
+function persistNotes(next) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(DASHBOARD_NOTES_KEY, next ?? '');
+  } catch (err) {
+    console.warn('[dashboard] Failed to persist notes', err);
+  }
+}
+
+const listeners = new Set();
+
+const state = {
+  snapshot: prepareInitialSnapshot(),
+};
+
+function prepareInitialSnapshot() {
+  const storedNotes = readStoredNotes();
+  if (storedNotes != null) {
+    return {
+      ...clone(dashboardFixture),
+      notes: storedNotes,
+    };
+  }
+  return clone(dashboardFixture);
+}
+
+function getSnapshot() {
+  return state.snapshot;
+}
+
+function setSnapshot(next) {
+  const prepared = {
+    ...clone(dashboardFixture),
+    ...clone(next || {}),
+  };
+  state.snapshot = prepared;
+  listeners.forEach((listener) => {
+    try {
+      listener(prepared);
+    } catch (err) {
+      console.error('[dashboard] Listener failed', err);
+    }
+  });
+  return prepared;
+}
+
+function updateNotes(notes) {
+  const current = getSnapshot();
+  const nextNotes = typeof notes === 'string' ? notes : '';
+  persistNotes(nextNotes);
+  return setSnapshot({
+    ...current,
+    notes: nextNotes,
+  });
+}
+
+function subscribe(listener) {
+  if (typeof listener !== 'function') return () => {};
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+const selectors = {
+  gauges: (snapshot) => snapshot.gauges,
+  device: (snapshot) => snapshot.device,
+  kpi: (snapshot) => snapshot.kpi,
+  rings: (snapshot) => snapshot.rings,
+  facts: (snapshot) => snapshot.facts,
+  notes: (snapshot) => snapshot.notes,
+};
+
+export const dashboard = {
+  fixture: dashboardFixture,
+  getSnapshot,
+  set: setSnapshot,
+  updateNotes,
+  subscribe,
+  selectors,
+};
+
+export default dashboard;

--- a/stores/dashboard.ts
+++ b/stores/dashboard.ts
@@ -1,0 +1,76 @@
+export type GaugeConfidence = 'manual' | 'auto' | 'timeout';
+
+export interface DashboardGaugeDelta {
+  energy: number;
+  srv: number;
+}
+
+export interface DashboardGauges {
+  energy: number;
+  srv: number;
+  delta15m: DashboardGaugeDelta;
+  confidence: GaugeConfidence;
+}
+
+export interface DashboardDeviceStatus {
+  online: boolean;
+  offline_min: number;
+  battery: number;
+  input: 'manual' | 'auto';
+}
+
+export interface DashboardBadge {
+  value: number;
+  badge: string;
+}
+
+export interface DashboardKpi {
+  wellbeing7: DashboardBadge;
+  cardio: DashboardBadge;
+  risk: DashboardBadge;
+  arrhythmia: DashboardBadge;
+}
+
+export interface DashboardRings {
+  stress: number;
+  burnout: number;
+  fatigue: number;
+  heartAge: DashboardBadge;
+}
+
+export interface DashboardFacts {
+  sleep_h: number | null;
+  alcohol_yday: boolean | null;
+  symptoms: boolean | null;
+  energy_adj: number;
+  late_meal: boolean | null;
+}
+
+export interface DashboardSnapshot {
+  gauges: DashboardGauges;
+  device: DashboardDeviceStatus;
+  kpi: DashboardKpi;
+  rings: DashboardRings;
+  facts: DashboardFacts;
+  notes: string;
+}
+
+export interface DashboardSelectors {
+  gauges: (snapshot: DashboardSnapshot) => DashboardGauges;
+  device: (snapshot: DashboardSnapshot) => DashboardDeviceStatus;
+  kpi: (snapshot: DashboardSnapshot) => DashboardKpi;
+  rings: (snapshot: DashboardSnapshot) => DashboardRings;
+  facts: (snapshot: DashboardSnapshot) => DashboardFacts;
+  notes: (snapshot: DashboardSnapshot) => string;
+}
+
+export interface DashboardStore {
+  fixture: DashboardSnapshot;
+  getSnapshot: () => DashboardSnapshot;
+  set: (snapshot: DashboardSnapshot) => DashboardSnapshot;
+  updateNotes: (text: string) => DashboardSnapshot;
+  subscribe: (listener: (snapshot: DashboardSnapshot) => void) => () => void;
+  selectors: DashboardSelectors;
+}
+
+export { dashboard as default, dashboard } from './dashboard.js';


### PR DESCRIPTION
## Summary
- add a dedicated HealthCabinet.html route with navigation entry
- implement dashboard store, recompute harness, and UI components for gauges, KPIs, rings, facts, and notes
- expand shared styling for health dashboard layout, responsive grids, and badges

## Testing
- ✅ `python -m http.server 4173`

------
https://chatgpt.com/codex/tasks/task_e_68e5ea75f72083329cb590510f4f575b