### PR TITLE
Add build versioning and service worker refresh flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .DS_Store
 npm-debug.log*
+public/version.json
+version.json

--- a/DiaryPlus.html
+++ b/DiaryPlus.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Diary Plus</title>
     <meta name="theme-color" content="#2563eb" />
-    <link rel="manifest" href="./manifest.webmanifest" />
-    <link rel="stylesheet" href="./shared/styles.css" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/shared/styles.css?v=__BUILD_COMMIT_SHORT__" />
   </head>
   <body class="app-shell" data-page="diary">
     <div data-include="nav"></div>
@@ -79,8 +79,10 @@
 
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
+    <script src="/shared/sw-client.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/shared/storage.js?v=__BUILD_COMMIT_SHORT__"></script>
+    <script src="/shared/nav-loader.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/scripts/diary.js?v=__BUILD_COMMIT_SHORT__" type="module"></script>
     <script>
       (function () {
         const form = document.getElementById('event-form');
@@ -272,13 +274,6 @@
 
         refresh();
 
-        if ('serviceWorker' in navigator) {
-          window.addEventListener('load', () => {
-            navigator.serviceWorker.register('./service-worker.js').catch((err) => {
-              console.warn('Service worker registration failed', err);
-            });
-          });
-        }
       })();
     </script>
   </body>

--- a/Map.html
+++ b/Map.html
@@ -1,10 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Map</title>
-    <link rel="stylesheet" href="./shared/styles.css" />
+    <meta name="theme-color" content="#2563eb" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/shared/styles.css?v=__BUILD_COMMIT_SHORT__" />
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
@@ -63,7 +65,8 @@
       </div>
     </main>
 
-    <script src="./shared/nav-loader.js" defer></script>
+    <script src="/shared/sw-client.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/shared/nav-loader.js?v=__BUILD_COMMIT_SHORT__" defer></script>
     <script>
       (function () {
         const LS_LOCATIONS = 'health_locations_v1';

--- a/Summary.html
+++ b/Summary.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Summary</title>
     <meta name="theme-color" content="#2563eb" />
-    <link rel="manifest" href="./manifest.webmanifest" />
-    <link rel="stylesheet" href="./shared/styles.css" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/shared/styles.css?v=__BUILD_COMMIT_SHORT__" />
   </head>
   <body class="app-shell" data-page="summary">
     <div data-include="nav"></div>
@@ -51,8 +51,9 @@
 
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
+    <script src="/shared/sw-client.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/shared/storage.js?v=__BUILD_COMMIT_SHORT__"></script>
+    <script src="/shared/nav-loader.js?v=__BUILD_COMMIT_SHORT__" defer></script>
     <script>
       (function () {
         const summaryCards = document.getElementById('summary-cards');
@@ -163,13 +164,6 @@
 
         refresh();
 
-        if ('serviceWorker' in navigator) {
-          window.addEventListener('load', () => {
-            navigator.serviceWorker.register('./service-worker.js').catch((err) => {
-              console.warn('Service worker registration failed', err);
-            });
-          });
-        }
       })();
     </script>
   </body>

--- a/health-cabinet/index.html
+++ b/health-cabinet/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Health cabinet</title>
     <meta name="theme-color" content="#2563eb" />
-    <link rel="manifest" href="./manifest.webmanifest" />
-    <link rel="stylesheet" href="./shared/styles.css" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/shared/styles.css?v=__BUILD_COMMIT_SHORT__" />
   </head>
   <body class="app-shell" data-page="health">
     <div data-include="nav"></div>
@@ -23,11 +23,17 @@
         <section class="health-dashboard__rings" data-section="rings"></section>
         <section class="health-dashboard__facts" data-section="facts"></section>
         <section class="health-dashboard__notes" data-section="notes"></section>
+        <section class="card card--settings" data-section="settings">
+          <h2>Cache controls</h2>
+          <p>Clear offline data and fetch the newest build if something looks outdated.</p>
+          <button type="button" class="button ghost" data-action="reset-cache">Reset cache</button>
+        </section>
       </div>
     </main>
 
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
-    <script type="module" src="./health/health-cabinet-page.js"></script>
+    <script src="/shared/sw-client.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/shared/storage.js?v=__BUILD_COMMIT_SHORT__"></script>
+    <script src="/shared/nav-loader.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script type="module" src="/health/health-cabinet-page.js?v=__BUILD_COMMIT_SHORT__"></script>
   </body>
 </html>

--- a/includes/nav.html
+++ b/includes/nav.html
@@ -1,12 +1,13 @@
 <aside class="sidebar">
   <div class="brand">
-    <a class="brand-link" href="Summary.html">Health • 2099</a>
+    <a class="brand-link" href="/Summary.html">Health • 2099</a>
+    <span class="build-badge" data-build-badge></span>
   </div>
 
   <nav class="nav" aria-label="Primary">
-    <a href="Summary.html" data-nav="summary" class="nav-link"><span>Summary</span></a>
-    <a href="HealthCabinet.html" data-nav="health" class="nav-link"><span>Health cabinet</span></a>
-    <a href="DiaryPlus.html" data-nav="diary" class="nav-link"><span>Diary</span></a>
-    <a href="Map.html" data-nav="map" class="nav-link"><span>Map</span></a>
+    <a href="/Summary.html" data-nav="summary" class="nav-link"><span>Summary</span></a>
+    <a href="/health-cabinet/" data-nav="health" class="nav-link"><span>Health cabinet</span></a>
+    <a href="/DiaryPlus.html" data-nav="diary" class="nav-link"><span>Diary</span></a>
+    <a href="/Map.html" data-nav="map" class="nav-link"><span>Map</span></a>
   </nav>
 </aside>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Diary, summary, and map snapshots with offline support.",
   "scripts": {
     "start": "npx serve .",
-    "build": "echo 'Static build only'",
+    "build": "node scripts/generate-version.mjs",
     "cap:init": "npx cap init Health2099 com.health2099.app --web-dir . --npm-client npm",
     "cap:copy": "npx cap copy",
     "cap:sync": "npx cap sync",

--- a/pocket_health_link.html
+++ b/pocket_health_link.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Health2099 Pocket Links</title>
     <meta name="theme-color" content="#2563eb" />
-    <link rel="manifest" href="./manifest.webmanifest" />
-    <link rel="stylesheet" href="./shared/styles.css" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/shared/styles.css?v=__BUILD_COMMIT_SHORT__" />
   </head>
   <body class="app-shell" data-page="links">
     <div data-include="nav"></div>
@@ -16,31 +16,28 @@
           <article class="link-card">
             <h1>Diary</h1>
             <p>Log hydration, sleep, movement, and daily notes.</p>
-            <a href="./DiaryPlus.html" class="button">Open diary</a>
+            <a href="/DiaryPlus.html" class="button">Open diary</a>
           </article>
           <article class="link-card">
             <h1>Summary</h1>
             <p>Check aggregated stats and quick actions.</p>
-            <a href="./Summary.html" class="button secondary">Open summary</a>
+            <a href="/Summary.html" class="button secondary">Open summary</a>
           </article>
           <article class="link-card">
             <h1>Map</h1>
             <p>Capture location snapshots and revisit your movement history.</p>
-            <a href="./Map.html" class="button">Open map</a>
+            <a href="/Map.html" class="button">Open map</a>
+          </article>
+          <article class="link-card">
+            <h1>Health cabinet</h1>
+            <p>Explore the full dashboard with live gauges, notes, and device signals.</p>
+            <a href="/health-cabinet/" class="button ghost">Open health cabinet</a>
           </article>
         </div>
       </div>
     </main>
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker.register('./service-worker.js').catch((err) => {
-            console.warn('Service worker registration failed', err);
-          });
-        });
-      }
-    </script>
+    <script src="/shared/sw-client.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/shared/storage.js?v=__BUILD_COMMIT_SHORT__"></script>
+    <script src="/shared/nav-loader.js?v=__BUILD_COMMIT_SHORT__" defer></script>
   </body>
 </html>

--- a/scripts/generate-version.mjs
+++ b/scripts/generate-version.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+function getGitValue(args) {
+  try {
+    return execSync(`git ${args}`, { cwd: ROOT_DIR }).toString().trim();
+  } catch (error) {
+    console.warn(`Failed to run git ${args}:`, error);
+    return '';
+  }
+}
+
+const gitCommit = getGitValue('rev-parse HEAD');
+const envCommit =
+  process.env.VERCEL_GIT_COMMIT_SHA ||
+  process.env.GITHUB_SHA ||
+  process.env.GIT_COMMIT ||
+  process.env.COMMIT_REF ||
+  '';
+
+const commit = gitCommit || envCommit || 'dev-build';
+
+const gitShort = getGitValue('rev-parse --short HEAD');
+const envShort = shorten(envCommit) || shorten(process.env.GIT_COMMIT) || '';
+const commitShort = gitShort || envShort || (commit !== 'dev-build' ? shorten(commit) : '') || 'dev';
+const builtAt = new Date().toISOString();
+
+const versionPayload = JSON.stringify({ commit, builtAt }, null, 2) + '\n';
+
+await fs.mkdir(path.join(ROOT_DIR, 'public'), { recursive: true });
+await fs.writeFile(path.join(ROOT_DIR, 'public', 'version.json'), versionPayload, 'utf8');
+await fs.writeFile(path.join(ROOT_DIR, 'version.json'), versionPayload, 'utf8');
+
+const htmlFiles = [
+  'DiaryPlus.html',
+  'Map.html',
+  'Summary.html',
+  'pocket_health_link.html',
+  path.join('health-cabinet', 'index.html'),
+];
+
+const assetPaths = [
+  '/shared/styles.css',
+  '/shared/sw-client.js',
+  '/shared/storage.js',
+  '/shared/nav-loader.js',
+  '/scripts/diary.js',
+  '/health/health-cabinet-page.js',
+];
+
+for (const relative of htmlFiles) {
+  const filePath = path.join(ROOT_DIR, relative);
+  let content = await fs.readFile(filePath, 'utf8');
+  for (const asset of assetPaths) {
+    const pattern = new RegExp(`${escapeRegExp(asset)}(?:\\?v=[^"'\\s]*)?`, 'g');
+    content = content.replace(pattern, `${asset}?v=${commitShort}`);
+  }
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+await updateSwClient();
+await updateServiceWorker();
+
+console.log(`Generated version metadata for ${commitShort} at ${builtAt}`);
+
+async function updateSwClient() {
+  const filePath = path.join(ROOT_DIR, 'shared', 'sw-client.js');
+  let content = await fs.readFile(filePath, 'utf8');
+  content = content
+    .replace(/commit:\s*'[^']*'/, `commit: '${commit}'`)
+    .replace(/commitShort:\s*'[^']*'/, `commitShort: '${commitShort}'`)
+    .replace(/builtAt:\s*'[^']*'/, `builtAt: '${builtAt}'`);
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+async function updateServiceWorker() {
+  const filePath = path.join(ROOT_DIR, 'service-worker.js');
+  let content = await fs.readFile(filePath, 'utf8');
+  content = content.replace(/const BUILD_VERSION = '[^']*';/, `const BUILD_VERSION = '${commitShort}';`);
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function shorten(value) {
+  if (!value || typeof value !== 'string') return '';
+  return value.slice(0, 7);
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,61 +1,110 @@
-const CACHE_NAME = 'health2099-cache-v1';
-const APP_SHELL = [
-  './',
-  './pocket_health_link.html',
-  './DiaryPlus.html',
-  './Summary.html',
-  './Map.html',
-  './shared/styles.css',
-  './shared/storage.js',
-  './shared/nav-loader.js',
-  './shared/vendor/leaflet/leaflet.css',
-  './shared/vendor/leaflet/leaflet.js',
-  './includes/nav.html',
-  './manifest.webmanifest',
-  './assets/icons/icon-192.svg',
-  './assets/icons/icon-512.svg',
-  './service-worker.js'
-];
+const BUILD_VERSION = '__BUILD_COMMIT_SHORT__';
+const HTML_CACHE = `html-${BUILD_VERSION}`;
+const STATIC_CACHE = `static-${BUILD_VERSION}`;
+const NETWORK_TIMEOUT_SECONDS = 3;
+const STATIC_EXTENSIONS = ['.js', '.css', '.woff', '.woff2', '.png', '.svg'];
 
-const BYPASS_HOSTS = ['tile.openstreetmap.org', 'unpkg.com'];
-
-self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)).then(() => self.skipWaiting())
-  );
+self.addEventListener('install', () => {
+  self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches
       .keys()
-      .then((keys) => Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))))
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== HTML_CACHE && key !== STATIC_CACHE)
+            .map((key) => caches.delete(key))
+        )
+      )
       .then(() => self.clients.claim())
   );
 });
 
-self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') {
-    return;
+self.addEventListener('message', (event) => {
+  if (event?.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
   }
-
-  const url = new URL(event.request.url);
-  const shouldBypass = BYPASS_HOSTS.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`));
-
-  if (shouldBypass) {
-    return;
-  }
-
-  event.respondWith(
-    caches.match(event.request).then((cached) => {
-      const fetchPromise = fetch(event.request)
-        .then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-          return response;
-        })
-        .catch(() => cached);
-      return cached || fetchPromise;
-    })
-  );
 });
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigation(request));
+    return;
+  }
+
+  if (isStaticAsset(url.pathname)) {
+    event.respondWith(staleWhileRevalidate(request));
+    return;
+  }
+});
+
+async function handleNavigation(request) {
+  const cache = await caches.open(HTML_CACHE);
+  try {
+    const response = await networkFirst(request.clone());
+    if (response && response.ok) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached) {
+      return cached;
+    }
+    throw error;
+  }
+}
+
+function networkFirst(request) {
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), NETWORK_TIMEOUT_SECONDS * 1000);
+    fetch(request, { signal: controller.signal })
+      .then((response) => {
+        clearTimeout(timeout);
+        resolve(response);
+      })
+      .catch((error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+  });
+}
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request);
+
+  const fetchPromise = fetch(request)
+    .then((response) => {
+      if (response && response.ok) {
+        cache.put(request, response.clone());
+      }
+      return response;
+    })
+    .catch((error) => {
+      if (cached) {
+        return cached;
+      }
+      throw error;
+    });
+
+  return cached || fetchPromise;
+}
+
+function isStaticAsset(pathname) {
+  return STATIC_EXTENSIONS.some((extension) => pathname.endsWith(extension));
+}

--- a/shared/nav-loader.js
+++ b/shared/nav-loader.js
@@ -1,9 +1,11 @@
 (function () {
+  const NAV_PATH = '/includes/nav.html';
+
   async function injectNav() {
     const container = document.querySelector('[data-include="nav"]');
     if (!container) return;
     try {
-      const response = await fetch('./includes/nav.html');
+      const response = await fetch(NAV_PATH, { cache: 'no-store' });
       const markup = await response.text();
       container.innerHTML = markup;
 
@@ -15,8 +17,25 @@
           activeLink.setAttribute('aria-current', 'page');
         }
       }
+
+      applyBuildBadge(container.querySelector('[data-build-badge]'));
     } catch (err) {
       console.error('Failed to load navigation include', err);
+    }
+  }
+
+  function applyBuildBadge(target) {
+    if (!target) return;
+    const info = window.__BUILD_INFO__;
+    if (!info || !info.commitShort || !info.builtAt) return;
+    try {
+      const date = new Date(info.builtAt);
+      const formatted = Number.isNaN(date.getTime()) ? info.builtAt : date.toLocaleString();
+      target.textContent = `v:${info.commitShort} · ${formatted}`;
+      target.setAttribute('title', `Build ${info.commit}\n${formatted}`);
+    } catch (err) {
+      console.warn('Failed to format build badge', err);
+      target.textContent = `v:${info.commitShort}`;
     }
   }
 

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -190,6 +190,26 @@ a:focus {
   text-decoration: none;
 }
 
+.build-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(45, 212, 191, 0.16);
+  color: rgba(203, 213, 225, 0.9);
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.build-badge:hover,
+.build-badge:focus {
+  background: rgba(45, 212, 191, 0.28);
+}
+
 .nav {
   display: flex;
   flex-direction: column;
@@ -478,6 +498,16 @@ textarea {
 
 .card--accent {
   background: var(--color-surface-alt);
+}
+
+.card--settings {
+  align-content: flex-start;
+  background: var(--color-surface-alt);
+  border-style: dashed;
+}
+
+.card--settings .button {
+  justify-self: start;
 }
 
 .card h2,
@@ -1045,6 +1075,42 @@ form {
 .toast.visible {
   opacity: 1;
   transform: translateY(0);
+}
+
+.update-toast {
+  position: fixed;
+  bottom: var(--space-4);
+  left: 50%;
+  transform: translate(-50%, 16px);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: rgba(15, 118, 110, 0.92);
+  color: #ecfeff;
+  padding: 0.85rem 1.2rem;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 1100;
+}
+
+.update-toast.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.update-toast__message {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 640px) {
+  .update-toast {
+    width: calc(100% - 2rem);
+    left: 50%;
+  }
 }
 
 .quick-actions {

--- a/shared/sw-client.js
+++ b/shared/sw-client.js
@@ -1,0 +1,120 @@
+(function () {
+  const BUILD_INFO = Object.freeze({
+    commit: '__BUILD_COMMIT__',
+    commitShort: '__BUILD_COMMIT_SHORT__',
+    builtAt: '__BUILD_DATE_ISO__',
+  });
+
+  window.__BUILD_INFO__ = BUILD_INFO;
+
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  let refreshing = false;
+
+  window.addEventListener('load', () => {
+    const swUrl = new URL('/service-worker.js', window.location.origin);
+    if (BUILD_INFO.commitShort && BUILD_INFO.commitShort !== '__BUILD_COMMIT_SHORT__') {
+      swUrl.searchParams.set('v', BUILD_INFO.commitShort);
+    }
+
+    navigator.serviceWorker
+      .register(swUrl.href)
+      .then((registration) => {
+        handleRegistration(registration);
+      })
+      .catch((err) => {
+        console.warn('[sw] Registration failed', err);
+      });
+  });
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
+  });
+
+  function handleRegistration(registration) {
+    if (!registration) return;
+
+    if (registration.waiting) {
+      promptUpdate(registration);
+    }
+
+    registration.addEventListener('updatefound', () => {
+      const newWorker = registration.installing;
+      if (!newWorker) return;
+      newWorker.addEventListener('statechange', () => {
+        if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+          promptUpdate(registration);
+        }
+      });
+    });
+  }
+
+  function promptUpdate(registration) {
+    const waiting = registration.waiting;
+    const toast = ensureToast();
+    toast.message.textContent = 'New version available';
+    toast.element.classList.add('visible');
+    toast.button.disabled = false;
+    toast.button.textContent = 'Reload';
+
+    const reload = () => {
+      if (!registration.waiting) {
+        return;
+      }
+      toast.button.disabled = true;
+      toast.button.textContent = 'Reloading…';
+      registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+    };
+
+    toast.button.onclick = reload;
+
+    if (waiting) {
+      waiting.addEventListener('statechange', (event) => {
+        if (event.target?.state === 'redundant') {
+          hideToast(toast.element);
+        }
+      });
+    }
+  }
+
+  function ensureToast() {
+    let element = document.querySelector('[data-update-toast]');
+    if (!element) {
+      element = document.createElement('div');
+      element.className = 'update-toast';
+      element.dataset.updateToast = 'true';
+      element.setAttribute('role', 'status');
+      const message = document.createElement('span');
+      message.className = 'update-toast__message';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'button primary';
+      button.textContent = 'Reload';
+      element.append(message, button);
+      document.body.appendChild(element);
+      return { element, message, button };
+    }
+    let message = element.querySelector('.update-toast__message');
+    let button = element.querySelector('button');
+    if (!message || !button) {
+      element.innerHTML = '';
+      message = document.createElement('span');
+      message.className = 'update-toast__message';
+      button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'button primary';
+      button.textContent = 'Reload';
+      element.append(message, button);
+    }
+    return { element, message, button };
+  }
+
+  function hideToast(element) {
+    if (!element) return;
+    element.classList.remove('visible');
+  }
+})();

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,28 @@
+{
+  "headers": [
+    {
+      "source": "/((?!.*\\.(?:css|js|woff2?|png|svg)$).*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/service-worker.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/(version.json|public/version.json|manifest.webmanifest)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/(.*\\.(?:css|js|woff2?|png|svg))",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- generate version metadata during builds and stamp asset URLs with the current commit
- display build information in the navigation, add an update toast with reload controls, and expose a cache reset button on the health cabinet page
- replace the service worker with network-first HTML and stale-while-revalidate static caching and add Vercel cache-control headers

## Testing
- node "$tmpdir/scripts/generate-version.mjs"

------
https://chatgpt.com/codex/tasks/task_e_68e5f62fd00483328920b9768be9565c