### PR TITLE
Add diagnostics tooling and refresh health dashboard UX

### DIFF
--- a/DiaryPlus.html
+++ b/DiaryPlus.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-store" />
     <title>Diary Plus</title>
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/Map.html
+++ b/Map.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-store" />
     <title>Map</title>
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/Summary.html
+++ b/Summary.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-store" />
     <title>Summary</title>
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/__diagnostics/index.html
+++ b/__diagnostics/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-store" />
+    <title>Diagnostics</title>
+    <meta name="theme-color" content="#2563eb" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/shared/styles.css?v=__BUILD_COMMIT_SHORT__" />
+  </head>
+  <body class="app-shell" data-page="diagnostics">
+    <div data-include="nav"></div>
+    <main class="app-main">
+      <div class="container flow diagnostics" data-diagnostics-root>
+        <header class="page-header">
+          <div class="page-header__content">
+            <span class="page-header__eyebrow">System</span>
+            <h1>Diagnostics</h1>
+            <p>Route manifest and build metadata for deployment verification.</p>
+          </div>
+        </header>
+
+        <section class="card">
+          <h2>Build</h2>
+          <dl class="diagnostics__list" data-build-info>
+            <div>
+              <dt>Commit</dt>
+              <dd>Loading…</dd>
+            </div>
+            <div>
+              <dt>Built</dt>
+              <dd>Loading…</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="card">
+          <h2>Routes</h2>
+          <div data-routes>Loading routes…</div>
+        </section>
+      </div>
+    </main>
+
+    <script src="/shared/sw-client.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/shared/storage.js?v=__BUILD_COMMIT_SHORT__"></script>
+    <script src="/shared/nav-loader.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+    <script src="/scripts/diagnostics.js?v=__BUILD_COMMIT_SHORT__" defer></script>
+  </body>
+</html>

--- a/health-cabinet/index.html
+++ b/health-cabinet/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-store" />
     <title>Health cabinet</title>
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="/manifest.webmanifest" />
@@ -12,10 +13,16 @@
     <div data-include="nav"></div>
     <main class="app-main">
       <div class="container flow health-dashboard" data-health-dashboard>
-        <header class="page-header">
-          <span class="page-header__eyebrow">Health cabinet</span>
-          <h1>Dashboard overview</h1>
-          <p>Live snapshot of wellness metrics powered by personal diary data and wearables.</p>
+        <header class="page-header health-dashboard__hero">
+          <div class="page-header__content">
+            <span class="page-header__eyebrow">Health cabinet</span>
+            <h1>Health cabinet</h1>
+            <p>Live snapshot of wellness metrics powered by personal diary data and wearables.</p>
+          </div>
+          <div class="page-header__meta">
+            <span class="badge page-header__badge" data-device-status>Device: Offline 10+ min · Battery 82% · ●○○ manual</span>
+            <span class="badge page-header__badge page-header__badge--version" data-version-badge title="Build version">v:dev</span>
+          </div>
         </header>
 
         <section class="health-dashboard__top" data-section="top"></section>

--- a/pocket_health_link.html
+++ b/pocket_health_link.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-store" />
     <title>Health2099 Pocket Links</title>
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/scripts/diagnostics.js
+++ b/scripts/diagnostics.js
@@ -1,0 +1,104 @@
+(function () {
+  function ready(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function formatDate(value) {
+    if (!value) return '—';
+    try {
+      const parsed = new Date(value);
+      if (Number.isNaN(parsed.getTime())) {
+        return value;
+      }
+      return parsed.toLocaleString();
+    } catch (err) {
+      console.warn('[diagnostics] Failed to format date', err);
+      return value;
+    }
+  }
+
+  function renderBuildInfo() {
+    const target = document.querySelector('[data-build-info]');
+    if (!target) return;
+    const info = window.__BUILD_INFO__ || {};
+    const rows = [
+      { label: 'Commit', value: info.commit || info.commitShort || 'unknown' },
+      { label: 'Short SHA', value: info.commitShort || 'unknown' },
+      { label: 'Built', value: formatDate(info.builtAt) },
+    ];
+    target.innerHTML = '';
+    rows.forEach((row) => {
+      const wrapper = document.createElement('div');
+      const dt = document.createElement('dt');
+      dt.textContent = row.label;
+      const dd = document.createElement('dd');
+      dd.textContent = row.value;
+      wrapper.append(dt, dd);
+      target.appendChild(wrapper);
+    });
+  }
+
+  async function loadRoutes() {
+    const container = document.querySelector('[data-routes]');
+    if (!container) return;
+    container.textContent = 'Loading routes…';
+    try {
+      const response = await fetch('/routes.json', { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch routes manifest (${response.status})`);
+      }
+      const manifest = await response.json();
+      renderRoutes(container, manifest);
+    } catch (error) {
+      console.error('[diagnostics] Unable to load routes manifest', error);
+      container.textContent = 'Failed to load routes manifest. Check console for details.';
+    }
+  }
+
+  function renderRoutes(container, manifest) {
+    container.innerHTML = '';
+    if (!manifest || !Array.isArray(manifest.routes) || manifest.routes.length === 0) {
+      container.textContent = 'No routes detected in the current build.';
+      return;
+    }
+
+    const meta = document.createElement('p');
+    meta.className = 'diagnostics__routes-meta';
+    const generatedLabel = manifest.generatedAt ? formatDate(manifest.generatedAt) : null;
+    meta.textContent = generatedLabel
+      ? `Manifest generated ${generatedLabel}`
+      : 'Manifest generation time unavailable';
+    container.appendChild(meta);
+
+    const list = document.createElement('ul');
+    list.className = 'diagnostics__routes';
+
+    manifest.routes.forEach((route) => {
+      const item = document.createElement('li');
+      const path = document.createElement('code');
+      path.textContent = route.path || 'unknown';
+
+      const description = document.createElement('span');
+      const file = route.file ? route.file : 'unknown file';
+      const title = route.title ? route.title : null;
+      description.textContent = title ? ` – ${title} (${file})` : ` – ${file}`;
+
+      item.append(path, description);
+      list.appendChild(item);
+    });
+
+    container.appendChild(list);
+  }
+
+  ready(() => {
+    renderBuildInfo();
+    loadRoutes();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('build:info', renderBuildInfo);
+    }
+  });
+})();

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -446,6 +446,11 @@ textarea {
   overflow: hidden;
 }
 
+.page-header__content {
+  display: grid;
+  gap: var(--space-3);
+}
+
 .page-header::after {
   content: '';
   position: absolute;
@@ -478,6 +483,37 @@ textarea {
   margin: 0;
   max-width: 60ch;
   color: var(--color-muted);
+}
+
+.page-header__meta {
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
+  display: grid;
+  gap: var(--space-2);
+  justify-items: end;
+  text-align: right;
+}
+
+.page-header__meta .badge {
+  box-shadow: var(--shadow-xs);
+}
+
+.page-header__badge--version {
+  background: rgba(56, 189, 248, 0.22);
+  color: var(--color-info);
+}
+
+@media (max-width: 720px) {
+  .page-header__meta {
+    position: static;
+    justify-items: start;
+    text-align: left;
+  }
+
+  .page-header.health-dashboard__hero {
+    padding-top: calc(var(--space-5) + 2.5rem);
+  }
 }
 
 .card-grid {
@@ -1134,6 +1170,63 @@ form {
   color: var(--color-primary);
   font-size: 0.8rem;
   font-weight: 600;
+}
+
+.diagnostics {
+  padding-bottom: var(--space-6);
+}
+
+.diagnostics__list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.diagnostics__list > div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.diagnostics__list dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-muted);
+}
+
+.diagnostics__list dd {
+  margin: 0;
+  color: var(--color-heading);
+  font-weight: 600;
+}
+
+.diagnostics__routes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.85rem;
+}
+
+.diagnostics__routes li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.diagnostics__routes code {
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--color-heading);
+}
+
+.diagnostics__routes-meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- disable service worker registration by default and notify the UI when build metadata is ready
- restyle the health cabinet header with a version badge and live device status sourced from the dashboard store
- generate a routes manifest during the build and expose a diagnostics page that surfaces the manifest alongside build details
- add Cache-Control hints to HTML entry points to reduce stale content while debugging

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e60f2a09888332a53f65d3d19e861f