### PR TITLE
Support configurable base path across app

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,16 +3,17 @@ import type { ReactNode } from 'react';
 import './globals.css';
 import AppShell from '@/components/layout/AppShell';
 import { BuildInfoProvider } from '@/components/providers/BuildInfoProvider';
+import { BASE_PATH } from '@/lib/base-path';
 
 export const metadata: Metadata = {
   title: 'Health • 2099',
   description: 'Diary, summary, map, and health cabinet insights in a unified dashboard.',
-  manifest: '/manifest.webmanifest',
+  manifest: BASE_PATH ? `${BASE_PATH}/manifest.webmanifest` : '/manifest.webmanifest',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" data-basepath={BASE_PATH || undefined}>
       <body className="app-shell">
         <BuildInfoProvider>
           <AppShell>{children}</AppShell>

--- a/components/providers/BuildInfoProvider.tsx
+++ b/components/providers/BuildInfoProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState } from 'react';
+import { withBasePath } from '@/lib/base-path';
 
 export type BuildInfo = {
   commit: string;
@@ -35,7 +36,7 @@ export function BuildInfoProvider({ children }: { children: React.ReactNode }) {
 
     async function load() {
       try {
-        const response = await fetch('/version.json', { cache: 'no-store' });
+        const response = await fetch(withBasePath('/version.json'), { cache: 'no-store' });
         if (!response.ok) return;
         const payload = await response.json();
         if (!cancelled) {

--- a/lib/base-path.ts
+++ b/lib/base-path.ts
@@ -1,0 +1,94 @@
+const ENV_BASE_PATH = normalizeBasePath(process.env.NEXT_PUBLIC_BASEPATH);
+
+function normalizeBasePath(value?: string | null): string {
+  if (!value) return '';
+  const trimmed = String(value).trim();
+  if (!trimmed || trimmed === '/' || trimmed === '.') {
+    return '';
+  }
+  let normalized = trimmed;
+  try {
+    if (/^https?:/i.test(normalized)) {
+      const url = new URL(normalized);
+      normalized = url.pathname || '';
+    }
+  } catch {
+    // Ignore URL parsing errors and fall back to raw value.
+  }
+  normalized = normalized.replace(/\/+$/, '');
+  if (!normalized) {
+    return '';
+  }
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+  return normalized === '/' ? '' : normalized;
+}
+
+declare global {
+  interface Window {
+    __BASE_PATH__?: string;
+    __NEXT_DATA__?: {
+      assetPrefix?: string;
+      [key: string]: unknown;
+    };
+  }
+}
+
+function readDocumentBasePath(): string {
+  if (typeof document === 'undefined') return '';
+  const datasetValue = document.documentElement?.dataset?.basepath;
+  return normalizeBasePath(datasetValue);
+}
+
+function readWindowBasePath(): string {
+  if (typeof window === 'undefined') return '';
+  if (typeof window.__BASE_PATH__ === 'string') {
+    return normalizeBasePath(window.__BASE_PATH__);
+  }
+  const assetPrefix = window.__NEXT_DATA__?.assetPrefix;
+  return normalizeBasePath(assetPrefix);
+}
+
+let cachedBasePath: string | null = null;
+
+export function getBasePath(): string {
+  if (typeof window === 'undefined') {
+    return ENV_BASE_PATH;
+  }
+  if (cachedBasePath != null) {
+    return cachedBasePath;
+  }
+  const fromDocument = readDocumentBasePath();
+  if (fromDocument) {
+    cachedBasePath = fromDocument;
+    return fromDocument;
+  }
+  const fromWindow = readWindowBasePath();
+  if (fromWindow) {
+    cachedBasePath = fromWindow;
+    return fromWindow;
+  }
+  cachedBasePath = ENV_BASE_PATH;
+  return cachedBasePath;
+}
+
+export function withBasePath(path: string): string {
+  const base = getBasePath();
+  if (!base) {
+    return path;
+  }
+  const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  if (!path.startsWith('/')) {
+    return path;
+  }
+  if (path === normalizedBase || path.startsWith(`${normalizedBase}/`)) {
+    return path;
+  }
+  return `${normalizedBase}${path}`;
+}
+
+export const BASE_PATH = ENV_BASE_PATH;
+
+export { normalizeBasePath };
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,51 @@
 /** @type {import('next').NextConfig} */
+function normalizeBasePath(value) {
+  if (!value) return '';
+  const trimmed = String(value).trim();
+  if (!trimmed || trimmed === '/' || trimmed === '.') {
+    return '';
+  }
+  let normalized = trimmed;
+  try {
+    if (/^https?:/i.test(normalized)) {
+      const url = new URL(normalized);
+      normalized = url.pathname || '';
+    }
+  } catch (error) {
+    // Ignore malformed URLs and fall back to the provided value.
+  }
+  normalized = normalized.replace(/\/+$/, '');
+  if (!normalized) {
+    return '';
+  }
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+  return normalized === '/' ? '' : normalized;
+}
+
+const isProd = process.env.NODE_ENV === 'production';
+const envBasePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASEPATH);
+const fallbackBasePath = normalizeBasePath(isProd ? '/prolevel' : '');
+const basePath = envBasePath || fallbackBasePath;
+const imagePath = basePath ? `${basePath}/_next/image` : '/_next/image';
+
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true,
+  },
+  ...(basePath
+    ? {
+        basePath,
+        assetPrefix: basePath,
+      }
+    : {}),
+  images: {
+    path: imagePath,
+  },
+  env: {
+    NEXT_PUBLIC_BASEPATH: basePath,
   },
   headers: async () => [
     {

--- a/scripts/diagnostics.js
+++ b/scripts/diagnostics.js
@@ -1,4 +1,59 @@
 (function () {
+  function normalizeBasePath(value) {
+    if (!value) return '';
+    var raw = String(value).trim();
+    if (!raw || raw === '/' || raw === '.') {
+      return '';
+    }
+    if (/^https?:/i.test(raw)) {
+      try {
+        raw = new URL(raw).pathname || '';
+      } catch (err) {
+        // Ignore malformed URLs.
+      }
+    }
+    raw = raw.replace(/\/+$/, '');
+    if (!raw) {
+      return '';
+    }
+    if (!raw.startsWith('/')) {
+      raw = '/' + raw;
+    }
+    return raw === '/' ? '' : raw;
+  }
+
+  function getBasePath() {
+    var globalObject = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
+    if (!globalObject) return '';
+    var doc = globalObject.document;
+    if (doc && doc.documentElement && doc.documentElement.dataset && doc.documentElement.dataset.basepath) {
+      var datasetValue = doc.documentElement.dataset.basepath;
+      var normalized = normalizeBasePath(datasetValue);
+      if (normalized) return normalized;
+    }
+    if (typeof globalObject.__BASE_PATH__ === 'string') {
+      var fromGlobal = normalizeBasePath(globalObject.__BASE_PATH__);
+      if (fromGlobal) return fromGlobal;
+    }
+    var assetPrefix = globalObject.__NEXT_DATA__ && globalObject.__NEXT_DATA__.assetPrefix;
+    if (typeof assetPrefix === 'string') {
+      return normalizeBasePath(assetPrefix);
+    }
+    return '';
+  }
+
+  function withBasePath(path) {
+    if (typeof path !== 'string' || !path.length || path[0] !== '/') {
+      return path;
+    }
+    var base = getBasePath();
+    if (!base) return path;
+    if (path === base || path.indexOf(base + '/') === 0) {
+      return path;
+    }
+    return base.endsWith('/') ? base.slice(0, -1) + path : base + path;
+  }
+
   function ready(callback) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', callback, { once: true });
@@ -47,7 +102,7 @@
     if (!container) return;
     container.textContent = 'Loading routes…';
     try {
-      const response = await fetch('/routes.json', { cache: 'no-store' });
+      const response = await fetch(withBasePath('/routes.json'), { cache: 'no-store' });
       if (!response.ok) {
         throw new Error(`Failed to fetch routes manifest (${response.status})`);
       }

--- a/shared/nav-loader.js
+++ b/shared/nav-loader.js
@@ -1,11 +1,66 @@
 (function () {
+  function normalizeBasePath(value) {
+    if (!value) return '';
+    var raw = String(value).trim();
+    if (!raw || raw === '/' || raw === '.') {
+      return '';
+    }
+    if (/^https?:/i.test(raw)) {
+      try {
+        raw = new URL(raw).pathname || '';
+      } catch (err) {
+        // Ignore malformed URLs.
+      }
+    }
+    raw = raw.replace(/\/+$/, '');
+    if (!raw) {
+      return '';
+    }
+    if (!raw.startsWith('/')) {
+      raw = '/' + raw;
+    }
+    return raw === '/' ? '' : raw;
+  }
+
+  function getBasePath() {
+    var globalObject = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
+    if (!globalObject) return '';
+    var doc = globalObject.document;
+    if (doc && doc.documentElement && doc.documentElement.dataset && doc.documentElement.dataset.basepath) {
+      var datasetValue = doc.documentElement.dataset.basepath;
+      var normalized = normalizeBasePath(datasetValue);
+      if (normalized) return normalized;
+    }
+    if (typeof globalObject.__BASE_PATH__ === 'string') {
+      var fromGlobal = normalizeBasePath(globalObject.__BASE_PATH__);
+      if (fromGlobal) return fromGlobal;
+    }
+    var assetPrefix = globalObject.__NEXT_DATA__ && globalObject.__NEXT_DATA__.assetPrefix;
+    if (typeof assetPrefix === 'string') {
+      return normalizeBasePath(assetPrefix);
+    }
+    return '';
+  }
+
+  function withBasePath(path) {
+    if (typeof path !== 'string' || !path.length || path[0] !== '/') {
+      return path;
+    }
+    var base = getBasePath();
+    if (!base) return path;
+    if (path === base || path.indexOf(base + '/') === 0) {
+      return path;
+    }
+    return base.endsWith('/') ? base.slice(0, -1) + path : base + path;
+  }
+
   const NAV_PATH = '/includes/nav.html';
 
   async function injectNav() {
     const container = document.querySelector('[data-include="nav"]');
     if (!container) return;
     try {
-      const response = await fetch(NAV_PATH, { cache: 'no-store' });
+      const response = await fetch(withBasePath(NAV_PATH), { cache: 'no-store' });
       const markup = await response.text();
       container.innerHTML = markup;
 


### PR DESCRIPTION
## Summary
- normalize and expose a configurable base path in Next.js config and the root layout metadata
- add a shared helper for resolving the active base path and use it when fetching build/version metadata
- update diagnostics, navigation loader, and service worker client scripts to respect the configured base path

## Testing
- npm run lint *(fails: `next` binary unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e61a9b889083328cf44617880701bd