### PR TITLE
fix(topbar): global inject + SW cache bypass (v6)

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,5 +3,5 @@
 <meta charset="utf-8">
 <title>Not found</title>
 <meta http-equiv="refresh" content="0; url=Summary.html">
-<script src="/Health2099/assets/topbar.bundle.js" defer></script>
+<script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
 </head>

--- a/DiaryPlus.html
+++ b/DiaryPlus.html
@@ -8,7 +8,8 @@
   <link rel="stylesheet" href="./_shared/styles.css" />
 
   <!-- TopBar: один-единственный тег -->
-  <script src="/Health2099/assets/topbar.bundle.js?v=5" defer></script>
+  <script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
+  <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
 </head>
   <body class="app-shell" data-page="diary">
     <div data-include="nav"></div>

--- a/HealthCabinet.html
+++ b/HealthCabinet.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-<script src="/Health2099/assets/topbar.bundle.js?v=4" defer></script>
   <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -9,7 +8,8 @@
   <link rel="stylesheet" href="./_shared/styles.css" />
 
   <!-- TopBar: один-единственный тег -->
-  <script src="/Health2099/assets/topbar.bundle.js?v=5" defer></script>
+  <script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
+  <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
 </head>
   <body class="app-shell" data-page="health">
     <div data-include="nav"></div>

--- a/Map.html
+++ b/Map.html
@@ -8,7 +8,8 @@
   <link rel="stylesheet" href="./_shared/styles.css" />
 
   <!-- TopBar: один-единственный тег -->
-  <script src="/Health2099/assets/topbar.bundle.js?v=5" defer></script>
+  <script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
+  <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
 </head>
   <body class="app-shell" data-page="map">
     <div data-include="nav"></div>

--- a/Summary.html
+++ b/Summary.html
@@ -8,7 +8,8 @@
   <link rel="stylesheet" href="./_shared/styles.css" />
 
   <!-- TopBar: один-единственный тег -->
-  <script src="/Health2099/assets/topbar.bundle.js?v=5" defer></script>
+  <script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
+  <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
 </head>
   <body class="app-shell" data-page="summary">
     <div data-include="nav"></div>

--- a/index.html
+++ b/index.html
@@ -4,5 +4,5 @@
 <title>Health2099</title>
 <meta http-equiv="refresh" content="0; url=Summary.html">
 <link rel="canonical" href="Summary.html">
-<script src="/Health2099/assets/topbar.bundle.js" defer></script>
+<script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
 </head>

--- a/pocket_health_link.html
+++ b/pocket_health_link.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="./manifest.webmanifest" />
     <link rel="stylesheet" href="./shared/styles.css" />
-  <script src="/Health2099/assets/topbar.bundle.js" defer></script>
+  <script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
   </head>
   <body class="app-shell" data-page="links">
     <div data-include="nav"></div>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'health2099-cache-v1';
+const CACHE_NAME = 'health2099-cache-v6';
 const APP_SHELL = [
   './',
   './pocket_health_link.html',
@@ -18,6 +18,7 @@ const APP_SHELL = [
 ];
 
 const BYPASS_HOSTS = ['tile.openstreetmap.org', 'unpkg.com'];
+const BYPASS_CACHE = [/assets\/topbar\.bundle\.js/];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -41,8 +42,14 @@ self.addEventListener('fetch', (event) => {
 
   const url = new URL(event.request.url);
   const shouldBypass = BYPASS_HOSTS.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`));
+  const shouldBypassCache = BYPASS_CACHE.some((pattern) => pattern.test(url.pathname));
 
   if (shouldBypass) {
+    return;
+  }
+
+  if (shouldBypassCache) {
+    event.respondWith(fetch(event.request));
     return;
   }
 


### PR DESCRIPTION
- Adds <script src="/Health2099/assets/topbar.bundle.js?v=6" defer> to all pages (inside <head>).
- Service Worker bypasses caching for the bundle and version bumped to v6 to force update.
- Adds small console log for sanity check: "TopBar type: object".

------
https://chatgpt.com/codex/tasks/task_e_68e67b0716848332b788a2982c4e63e4