### PR TITLE
fix(map): robust Leaflet load (local+CDN), container height; re-enable global TopBar; SW bypass (v8)

### DIFF
--- a/Map.html
+++ b/Map.html
@@ -6,9 +6,24 @@
   <meta name="theme-color" content="#2563eb" />
   <link rel="manifest" href="./manifest.webmanifest" />
   <link rel="stylesheet" href="./shared/styles.css" />
+  <!-- Leaflet CSS -->
   <link rel="stylesheet" href="./shared/vendor/leaflet/leaflet.css" />
-  <script src="./shared/vendor/leaflet/leaflet.js" defer></script>
-  <script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
+
+  <!-- Leaflet JS (local first, CDN fallback via onerror); must appear BEFORE any script that uses L -->
+  <script
+    src="./shared/vendor/leaflet/leaflet.js"
+    defer
+    onerror="
+      (function(){
+        var sc=document.createElement('script');
+        sc.src='https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+        sc.defer=true; document.head.appendChild(sc);
+        var lc=document.createElement('link'); lc.rel='stylesheet';
+        lc.href='https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+        document.head.appendChild(lc);
+      })();
+    "
+  ></script>
 
   </head>
   <body class="app-shell" data-page="map">
@@ -47,7 +62,7 @@
         </div>
 
         <div class="map-layout">
-          <div id="map" class="map" aria-label="Locations map"></div>
+          <div id="map" class="map" aria-label="Locations map" style="height:520px;"></div>
           <aside class="panel" aria-label="Snapshot history">
             <div class="muted" style="margin-bottom: 0.5rem;">History</div>
             <ul id="list" class="list"></ul>
@@ -59,6 +74,7 @@
     <script src="./shared/storage.js"></script>
     <script src="./shared/nav-loader.js"></script>
     <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
+    <script>window.addEventListener('load',()=>console.log('Leaflet ready:', !!window.L));</script>
     <script>
       (function () {
         const LS_LOCATIONS = 'health_locations_v1';

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'health2099-cache-v6-restore-mapfix';
+const CACHE_NAME = 'health2099-cache-v6-restore-mapfix-v8';
 const APP_SHELL = [
   './',
   './pocket_health_link.html',
@@ -18,7 +18,13 @@ const APP_SHELL = [
 ];
 
 const BYPASS_HOSTS = ['tile.openstreetmap.org', 'unpkg.com'];
-const BYPASS_CACHE = [/assets\/topbar\.bundle\.js/];
+const BYPASS_CACHE = [
+  /assets\/topbar\.bundle\.js/,
+  /shared\/vendor\/leaflet\/leaflet\.js/,
+  /shared\/vendor\/leaflet\/leaflet\.css/,
+  /unpkg\.com\/leaflet/,
+  /tile\.openstreetmap\.org/
+];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -42,7 +48,7 @@ self.addEventListener('fetch', (event) => {
 
   const url = new URL(event.request.url);
   const shouldBypass = BYPASS_HOSTS.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`));
-  const shouldBypassCache = BYPASS_CACHE.some((pattern) => pattern.test(url.pathname));
+  const shouldBypassCache = BYPASS_CACHE.some((pattern) => pattern.test(event.request.url));
 
   if (shouldBypass) {
     return;

--- a/shared/nav-loader.js
+++ b/shared/nav-loader.js
@@ -2,7 +2,7 @@
   const ID = 'topbar-bundle';
   if (!document.getElementById(ID)) {
     const s = document.createElement('script');
-    s.src = '/Health2099/assets/topbar.bundle.js?v=6';
+    s.src = '/Health2099/assets/topbar.bundle.js?v=8';
     s.defer = true;
     s.id = ID;
     document.head.appendChild(s);


### PR DESCRIPTION
## Summary
- Update Map.html head to load Leaflet from the local vendor bundle with CDN fallback and ensure diagnostics are in place
- Ensure the map container exposes an explicit height for layout stability
- Refresh the TopBar loader and service worker configuration for v8 assets and cache bypassing

## Testing
- Not run (not requested)

## Edited Files
- Map.html
- shared/nav-loader.js
- service-worker.js

## Confirmation
- Map.html now includes leaflet.css + leaflet.js once and before any script using L
- #map has explicit height or class height
- shared/nav-loader.js injects /Health2099/assets/topbar.bundle.js?v=8
- service-worker.js version bumped and bypass patterns added

------
https://chatgpt.com/codex/tasks/task_e_68e68544a688833297f64b2cf32c7c7e