### PR TITLE
feat: premium Revolut-inspired summary dashboard

### DIFF
--- a/Summary.html
+++ b/Summary.html
@@ -1,177 +1,159 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#2563eb" />
-  <link rel="manifest" href="./manifest.webmanifest" />
-  <link rel="stylesheet" href="./shared/styles.css" />
-
-</head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#2563eb" />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="preload" href="assets/css/summary.css?v=20240714" as="style" />
+    <link rel="preload" href="assets/css/animations.css?v=20240714" as="style" />
+    <link rel="preload" href="assets/css/timeline.css?v=20240714" as="style" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.18), transparent 55%),
+          radial-gradient(circle at 80% 0%, rgba(15, 118, 110, 0.28), transparent 60%),
+          linear-gradient(160deg, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 1) 100%);
+        color: #f8fafc;
+      }
+      .app-shell {
+        display: grid;
+        min-height: 100vh;
+        grid-template-rows: auto 1fr auto;
+      }
+      .summary-viewport {
+        max-width: 1280px;
+        margin: 0 auto;
+        width: 100%;
+        padding: clamp(1.5rem, 2vw, 3rem) clamp(1rem, 2vw, 3rem) 3rem;
+        display: grid;
+        gap: 1.75rem;
+      }
+      .summary-header,
+      .summary-main,
+      .summary-sidebar {
+        background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(15, 23, 42, 0.58));
+        border-radius: 24px;
+        border: 1px solid rgba(96, 165, 250, 0.18);
+        box-shadow: 0 12px 48px rgba(2, 6, 23, 0.38);
+        backdrop-filter: blur(28px);
+        -webkit-backdrop-filter: blur(28px);
+      }
+      .summary-header {
+        padding: 2.5rem clamp(2rem, 3vw, 3rem);
+      }
+      .summary-main {
+        padding: clamp(1.75rem, 2vw, 2.5rem);
+        display: grid;
+        gap: 1.75rem;
+      }
+      .summary-sidebar {
+        padding: clamp(1.5rem, 2vw, 2.25rem);
+        display: grid;
+        gap: 1.5rem;
+        align-content: start;
+      }
+      @media (min-width: 960px) {
+        .summary-viewport {
+          grid-template-columns: 2fr 1fr;
+          align-items: start;
+        }
+      }
+    </style>
+    <link rel="stylesheet" href="assets/css/theme.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" href="assets/css/summary.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" href="assets/css/animations.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" href="assets/css/timeline.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" href="assets/css/badges.css?v=20240714" media="print" onload="this.media='all'" />
+    <noscript>
+      <link rel="stylesheet" href="assets/css/theme.css?v=20240714" />
+      <link rel="stylesheet" href="assets/css/summary.css?v=20240714" />
+      <link rel="stylesheet" href="assets/css/animations.css?v=20240714" />
+      <link rel="stylesheet" href="assets/css/timeline.css?v=20240714" />
+      <link rel="stylesheet" href="assets/css/badges.css?v=20240714" />
+    </noscript>
+  </head>
   <body class="app-shell" data-page="summary">
     <div data-include="nav"></div>
-    <main class="app-main">
-      <div class="container flow">
-        <header class="page-header">
-          <span class="page-header__eyebrow">Summary</span>
-          <h1>Wellness snapshot</h1>
-          <p>Review trends, averages, and quick actions powered by your shared storage. Everything updates live across tabs.</p>
-          <span class="badge">Live insights</span>
-        </header>
-
-        <section class="card-grid" id="summary-cards"></section>
-        <section class="card-grid" id="averages"></section>
-
-        <section class="card">
-          <h2>Quick actions</h2>
-          <p>Log frequent habits without opening the diary.</p>
-          <div class="quick-actions">
-            <button type="button" data-action="water" data-value="250">+250 ml water</button>
-            <button type="button" data-action="water" data-value="500">+500 ml water</button>
-            <button type="button" class="secondary" data-action="steps" data-value="1000">+1k steps</button>
-            <button type="button" class="secondary" data-action="sleep" data-value="480">+8h sleep</button>
+    <div class="summary-viewport">
+      <header id="summary-header" class="summary-header" role="banner"></header>
+      <main class="summary-main" id="main" role="main">
+        <section aria-labelledby="kpi-heading" class="kpi-grid" id="kpi-grid" role="region">
+          <h2 id="kpi-heading" class="visually-hidden">Key wellness metrics</h2>
+        </section>
+        <section class="quick-actions" aria-labelledby="actions-heading" role="region">
+          <header>
+            <h2 id="actions-heading">Quick actions</h2>
+            <p>Log habits in a tap. Offline entries queue automatically.</p>
+          </header>
+          <div class="quick-actions__grid" id="quick-actions" role="group" aria-label="Quick log actions"></div>
+          <div>
+            <button type="button" id="action-note" class="card-press">Add note</button>
           </div>
         </section>
-
-        <section class="table-wrapper" aria-live="polite">
-          <table id="recent-table">
-            <thead>
-              <tr>
-                <th scope="col">Type</th>
-                <th scope="col">Value</th>
-                <th scope="col">Note</th>
-                <th scope="col">Created</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
+        <section class="timeline" aria-labelledby="timeline-heading" role="region">
+          <header>
+            <div>
+              <h2 id="timeline-heading">Today</h2>
+              <p id="timeline-count" class="timeline-meta"></p>
+            </div>
+            <button type="button" class="card-press" id="seed-demo">Seed demo data</button>
+          </header>
+          <div class="timeline-list" id="timeline-list" aria-live="polite"></div>
         </section>
-      </div>
-    </main>
-
-    <div class="toast" id="toast" role="status" aria-live="polite"></div>
-
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
-    <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
-    <script>
-      (function () {
-        const summaryCards = document.getElementById('summary-cards');
-        const averagesCards = document.getElementById('averages');
-        const tableBody = document.querySelector('#recent-table tbody');
-        const toast = document.getElementById('toast');
-        const quickButtons = document.querySelectorAll('[data-action]');
-
-        function showToast(message) {
-          toast.textContent = message;
-          toast.classList.add('visible');
-          setTimeout(() => toast.classList.remove('visible'), 2400);
-        }
-
-        function renderSummary() {
-          const now = new Date();
-          const day = StorageAPI.aggregates('day', now);
-          const week = StorageAPI.aggregates('week', now);
-          const month = StorageAPI.aggregates('month', now);
-          summaryCards.innerHTML = [
-            card('Water today', `${day.water_ml} ml`),
-            card('Steps today', `${day.steps}`),
-            card('Sleep this week', `${Math.round(week.sleep_min / 60)} h`),
-            card('Meds this month', `${month.meds_count}`),
-          ].join('');
-          averagesCards.innerHTML = [
-            card('Stress avg (day)', `${day.stress_avg}`),
-            card('Energy avg (day)', `${day.energy_avg}`),
-            card('SRV avg (day)', `${day.srv_avg}`),
-            card('Caffeine (week)', `${week.caffeine_mg} mg`),
-          ].join('');
-        }
-
-        function card(title, value) {
-          return `<article class="card"><h3>${title}</h3><strong>${value}</strong></article>`;
-        }
-
-        function renderRecent() {
-          const events = StorageAPI.loadEvents().filter((event) => !event.deleted_at).slice(0, 8);
-          if (!events.length) {
-            tableBody.innerHTML = `<tr><td colspan="4"><div class="empty-state">No events logged yet.</div></td></tr>`;
-            return;
-          }
-          tableBody.innerHTML = '';
-          events.forEach((event) => {
-            const row = document.createElement('tr');
-            row.innerHTML = `
-              <td>${event.type}</td>
-              <td>${event.value_number ?? ''}</td>
-              <td>${escapeHtml(event.note || '')}</td>
-              <td>${formatDate(event.created_at)}</td>
-            `;
-            tableBody.appendChild(row);
-          });
-        }
-
-        function escapeHtml(text) {
-          const div = document.createElement('div');
-          div.textContent = text;
-          return div.innerHTML;
-        }
-
-        function formatDate(value) {
-          const parsed = new Date(value);
-          if (Number.isNaN(parsed.getTime())) return '';
-          return parsed.toLocaleString();
-        }
-
-        quickButtons.forEach((button) => {
-          button.addEventListener('click', () => {
-            const action = button.dataset.action;
-            const value = Number(button.dataset.value || 0);
-            addQuickEvent(action, value);
-          });
-        });
-
-        function addQuickEvent(type, value) {
-          const now = new Date().toISOString();
-          const event = {
-            id: createId(),
-            type,
-            value_number: value || null,
-            note: '',
-            created_at: now,
-            updated_at: now,
-          };
-          const events = StorageAPI.loadEvents();
-          events.unshift(event);
-          StorageAPI.saveEvents(events);
-          renderSummary();
-          renderRecent();
-          showToast(`${type} logged`);
-        }
-
-        function createId() {
-          if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-            return crypto.randomUUID();
-          }
-          return 'evt_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
-        }
-
-        function refresh() {
-          renderSummary();
-          renderRecent();
-        }
-
-        window.addEventListener('health:changed', refresh);
-
-        refresh();
-
-        if ('serviceWorker' in navigator) {
-          window.addEventListener('load', () => {
-            navigator.serviceWorker.register('./service-worker.js').catch((err) => {
-              console.warn('Service worker registration failed', err);
-            });
-          });
-        }
-      })();
-    </script>
+        <section class="insights" aria-labelledby="insights-heading" id="insights" role="region">
+          <h2 id="insights-heading">Insights &amp; nudges</h2>
+        </section>
+        <section class="streaks" aria-labelledby="streaks-heading" role="region">
+          <h2 id="streaks-heading">Streaks</h2>
+          <div class="streak-list" id="streak-list"></div>
+        </section>
+        <section class="badges" aria-labelledby="badges-heading" role="region">
+          <h2 id="badges-heading" class="visually-hidden">Badges</h2>
+          <div id="badge-collection"></div>
+        </section>
+      </main>
+      <aside class="summary-sidebar" aria-labelledby="sidebar-heading">
+        <h2 id="sidebar-heading" class="visually-hidden">Sidebar</h2>
+        <section class="sidebar-section" aria-labelledby="targets-heading">
+          <header>
+            <h3 id="targets-heading">Targets</h3>
+          </header>
+          <div class="target-item">
+            <label for="target-water">Water goal (ml)</label>
+            <input id="target-water" type="number" inputmode="numeric" min="0" />
+          </div>
+          <div class="target-item">
+            <label for="target-steps">Steps goal</label>
+            <input id="target-steps" type="number" inputmode="numeric" min="0" />
+          </div>
+          <div class="target-item">
+            <label for="target-sleep">Sleep goal (minutes)</label>
+            <input id="target-sleep" type="number" inputmode="numeric" min="0" />
+          </div>
+          <div class="target-item">
+            <label for="target-caffeine">Caffeine ceiling (mg)</label>
+            <input id="target-caffeine" type="number" inputmode="numeric" min="0" />
+          </div>
+        </section>
+        <section class="sidebar-section" aria-labelledby="meds-heading">
+          <header>
+            <h3 id="meds-heading">Today&apos;s meds</h3>
+            <button type="button" id="add-med" class="card-press">Add</button>
+          </header>
+          <div class="meds-list" id="meds-list" aria-live="polite"></div>
+        </section>
+      </aside>
+    </div>
+    <footer class="summary-footer" role="contentinfo">
+      Synced via shared storage · Broadcast ready
+    </footer>
+    <script src="./shared/nav-loader.js" defer></script>
+    <script type="module" src="assets/js/summary-page.js?v=20240714" defer></script>
   </body>
 </html>

--- a/assets/css/animations.css
+++ b/assets/css/animations.css
@@ -1,0 +1,40 @@
+.card-hover {
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.card-hover:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow);
+}
+
+.card-press:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.goal-pulse {
+  animation: goalPulse 550ms ease-out;
+}
+
+@keyframes goalPulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(96, 165, 250, 0.35);
+  }
+  70% {
+    transform: scale(1.02);
+    box-shadow: 0 0 0 18px rgba(96, 165, 250, 0);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-hover,
+  .card-press,
+  .goal-pulse {
+    transition-duration: 0.01ms !important;
+    animation: none !important;
+  }
+}

--- a/assets/css/badges.css
+++ b/assets/css/badges.css
@@ -1,0 +1,17 @@
+.badge-animate {
+  animation: badgePop 420ms ease;
+}
+
+@keyframes badgePop {
+  0% {
+    transform: scale(0.85);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+  }
+}

--- a/assets/css/summary.css
+++ b/assets/css/summary.css
@@ -1,0 +1,556 @@
+:root {
+  --container-max: 1280px;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+}
+
+.summary-viewport {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.75rem;
+  padding: clamp(1.5rem, 2vw, 3rem) clamp(1rem, 2vw, 3rem) 3rem;
+  max-width: var(--container-max);
+  margin: 0 auto;
+  width: 100%;
+}
+
+.summary-main,
+.summary-sidebar,
+.summary-header,
+.summary-footer,
+.kpi-grid,
+.quick-actions,
+.timeline,
+.insights,
+.streaks,
+.badges {
+  background: var(--glass-gradient);
+  border: var(--glass-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(var(--backdrop-blur));
+  -webkit-backdrop-filter: blur(var(--backdrop-blur));
+  position: relative;
+}
+
+.summary-header {
+  padding: 2.5rem clamp(2rem, 3vw, 3rem);
+  display: grid;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+.summary-header__inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.summary-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% -10%, rgba(96, 165, 250, 0.28), transparent 60%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.summary-header h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0;
+  color: var(--text);
+}
+
+.summary-header__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.summary-header__status {
+  display: flex;
+  align-items: center;
+}
+
+.snapshot-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(96, 165, 250, 0.24);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+}
+
+.snapshot-pill strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.device-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  border-radius: 1.5rem;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  font-size: 0.9rem;
+}
+
+.device-status[data-state='green'] {
+  border-color: rgba(52, 211, 153, 0.32);
+  color: var(--ok);
+}
+
+.device-status[data-state='yellow'] {
+  border-color: rgba(250, 204, 21, 0.32);
+  color: var(--warn);
+}
+
+.device-status[data-state='red'] {
+  border-color: rgba(248, 113, 113, 0.32);
+  color: var(--danger);
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.summary-columns {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.summary-main {
+  padding: clamp(1.75rem, 2vw, 2.5rem);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.summary-sidebar {
+  padding: clamp(1.5rem, 2vw, 2.25rem);
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.kpi-card {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: calc(var(--radius) - 6px);
+  background: rgba(2, 6, 23, 0.35);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  position: relative;
+  overflow: hidden;
+}
+
+.kpi-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(96, 165, 250, 0.25), transparent 55%);
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.kpi-card:hover::after {
+  opacity: 1;
+}
+
+.kpi-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  z-index: 1;
+}
+
+.kpi-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.kpi-badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.18);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.kpi-badge[data-state='warning'] {
+  background: rgba(250, 204, 21, 0.15);
+  color: var(--warn);
+}
+
+.kpi-badge[data-state='danger'] {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--danger);
+}
+
+.kpi-value {
+  font-size: clamp(1.65rem, 3vw, 2.15rem);
+  font-weight: 700;
+  color: var(--text);
+}
+
+.kpi-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.sparkline {
+  width: 100%;
+  height: 56px;
+}
+
+.quick-actions {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.quick-actions h2 {
+  margin: 0 0 0.25rem;
+  font-size: 1.4rem;
+}
+
+.quick-actions__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.quick-action {
+  border-radius: 1.5rem;
+  padding: 0.95rem 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(96, 165, 250, 0.16);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.quick-action span {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.quick-action small {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.quick-action:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-soft);
+}
+
+.quick-action:active {
+  transform: translateY(1px);
+}
+
+.timeline {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.timeline-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.2rem;
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  transition: transform 200ms ease;
+}
+
+.timeline-item:hover {
+  transform: translateY(-2px);
+}
+
+.timeline-empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--muted);
+  border-radius: 18px;
+  border: 1px dashed rgba(96, 165, 250, 0.24);
+  background: rgba(2, 6, 23, 0.3);
+}
+
+.timeline-empty button {
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.16);
+  color: var(--primary);
+}
+
+.timeline-item[data-type='water'] {
+  border-left: 4px solid rgba(96, 165, 250, 0.6);
+}
+
+.timeline-item[data-type='steps'] {
+  border-left: 4px solid rgba(52, 211, 153, 0.6);
+}
+
+.timeline-item[data-type='sleep'] {
+  border-left: 4px solid rgba(129, 140, 248, 0.6);
+}
+
+.timeline-item[data-type='caffeine'] {
+  border-left: 4px solid rgba(250, 204, 21, 0.6);
+}
+
+.timeline-item[data-type='meds'] {
+  border-left: 4px solid rgba(248, 113, 113, 0.6);
+}
+
+.timeline-editable input,
+.timeline-editable select,
+.timeline-editable textarea {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(2, 6, 23, 0.45);
+  color: var(--text);
+  font: inherit;
+}
+
+.timeline-editable textarea {
+  min-height: 60px;
+}
+
+.timeline-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.insights {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-item {
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(96, 165, 250, 0.16);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.insight-item strong {
+  color: var(--text);
+}
+
+.streaks {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.streak-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.streak {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.9rem 1.2rem;
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(96, 165, 250, 0.14);
+}
+
+.badges {
+  padding: 1.2rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+#badge-collection {
+  display: contents;
+}
+
+.badge-chip {
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  background: rgba(96, 165, 250, 0.2);
+  color: var(--primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.sidebar-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.sidebar-section header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sidebar-section h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.target-item {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.target-item label {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.target-item input {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  color: var(--text);
+}
+
+.meds-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.meds-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+}
+
+.meds-item label {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.toast-container {
+  position: fixed;
+  bottom: clamp(1rem, 5vw, 3rem);
+  right: clamp(1rem, 4vw, 3rem);
+  z-index: 1000;
+  display: grid;
+  gap: 0.75rem;
+  max-width: 320px;
+}
+
+.toast {
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.88);
+  border: 1px solid rgba(96, 165, 250, 0.24);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.toast button {
+  justify-self: start;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.15);
+  color: var(--primary);
+}
+
+.summary-footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: rgba(148, 163, 184, 0.6);
+}
+
+@media (min-width: 960px) {
+  .summary-viewport {
+    grid-template-columns: 2fr 1fr;
+    align-items: start;
+  }
+
+  .summary-columns {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .summary-main {
+    order: 1;
+  }
+
+  .summary-sidebar {
+    position: sticky;
+    top: 120px;
+  }
+}
+
+@media (max-width: 959px) {
+  .summary-header,
+  .summary-main,
+  .summary-sidebar,
+  .summary-footer,
+  .quick-actions,
+  .timeline,
+  .insights,
+  .streaks,
+  .badges {
+    border-radius: clamp(18px, 5vw, var(--radius));
+  }
+}

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,79 @@
+:root {
+  --bg: #020617;
+  --bg-alt: #0f172a;
+  --card: rgba(15, 23, 42, 0.76);
+  --glass: rgba(15, 23, 42, 0.58);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --primary: #60a5fa;
+  --ok: #34d399;
+  --warn: #facc15;
+  --danger: #f87171;
+  --radius: 24px;
+  --shadow: 0 28px 120px rgba(2, 6, 23, 0.55);
+  --shadow-soft: 0 12px 48px rgba(2, 6, 23, 0.38);
+  --border: 1px solid rgba(148, 163, 184, 0.22);
+  --glass-border: 1px solid rgba(96, 165, 250, 0.18);
+  --backdrop-blur: 28px;
+  --gradient-bg: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.18), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(15, 118, 110, 0.28), transparent 60%),
+    linear-gradient(160deg, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 0.98) 55%, rgba(2, 6, 23, 1) 100%);
+  --glass-gradient: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(15, 23, 42, 0.58));
+  --focus-ring: 0 0 0 3px rgba(96, 165, 250, 0.45);
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--gradient-bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/css/timeline.css
+++ b/assets/css/timeline.css
@@ -1,0 +1,34 @@
+.timeline-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(96, 165, 250, 0.24);
+}
+
+.timeline-content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.timeline-content strong {
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.timeline-meta {
+  color: var(--muted);
+  font-size: 0.8rem;
+  display: flex;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.timeline-note {
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.85rem;
+}

--- a/assets/js/charts.js
+++ b/assets/js/charts.js
@@ -1,0 +1,73 @@
+let chartModulePromise;
+
+function ensureChart() {
+  if (window.Chart) return Promise.resolve(window.Chart);
+  if (!chartModulePromise) {
+    chartModulePromise = import('https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js').then((module) => {
+      const Chart = module.Chart || module.default;
+      window.Chart = Chart;
+      return Chart;
+    });
+  }
+  return chartModulePromise;
+}
+
+export function renderSparkline(canvas, data, color = 'rgba(96, 165, 250, 0.6)') {
+  if (!canvas) return;
+  ensureChart().then((Chart) => {
+    if (!Chart) return;
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    if (canvas.__chartInstance) {
+      canvas.__chartInstance.data.datasets[0].data = data;
+      canvas.__chartInstance.update();
+      return;
+    }
+    canvas.__chartInstance = new Chart(context, {
+      type: 'line',
+      data: {
+        labels: data.map((_, index) => index + 1),
+        datasets: [
+          {
+            data,
+            borderColor: color,
+            backgroundColor: color.replace('0.6', '0.18'),
+            fill: true,
+            tension: 0.4,
+            borderWidth: 2,
+            pointRadius: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: false },
+        },
+        scales: {
+          x: { display: false },
+          y: { display: false },
+        },
+      },
+    });
+  });
+}
+
+export function lazySparkline(canvas, data, color) {
+  if (!canvas) return;
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          renderSparkline(canvas, data, color);
+          observer.disconnect();
+        }
+      });
+    }, { threshold: 0.2 });
+    observer.observe(canvas);
+  } else {
+    renderSparkline(canvas, data, color);
+  }
+}

--- a/assets/js/dev-seed.js
+++ b/assets/js/dev-seed.js
@@ -1,0 +1,64 @@
+import { SharedStorage } from './sharedStorage.js';
+
+export function initDevSeed() {
+  const button = document.getElementById('seed-demo');
+  if (!button) return;
+  button.addEventListener('click', () => {
+    const days = 7;
+    const entries = [];
+    const now = new Date();
+    for (let d = 0; d < days; d += 1) {
+      const dayDate = new Date(now.getTime() - d * 86400000);
+      ['water', 'steps', 'sleep', 'caffeine', 'meds'].forEach((type) => {
+        const count = type === 'meds' ? 1 : 2;
+        for (let i = 0; i < count; i += 1) {
+          const timestamp = new Date(dayDate);
+          timestamp.setHours(8 + i * 4, Math.floor(Math.random() * 60), 0, 0);
+          entries.push({ type, value: valueForType(type), createdAt: timestamp.toISOString(), note: noteForType(type) });
+        }
+      });
+    }
+    entries.forEach((entry) => {
+      SharedStorage.pushLog(entry.type, entry.value, { createdAt: entry.createdAt, note: entry.note });
+    });
+    SharedStorage.setSettings({
+      city: 'Amsterdam',
+      deviceBattery: 82,
+      lastDevicePing: new Date().toISOString(),
+    });
+  });
+}
+
+function valueForType(type) {
+  switch (type) {
+    case 'water':
+      return 250 + Math.floor(Math.random() * 400);
+    case 'steps':
+      return 2000 + Math.floor(Math.random() * 4000);
+    case 'sleep':
+      return 360 + Math.floor(Math.random() * 120);
+    case 'caffeine':
+      return 80 + Math.floor(Math.random() * 60);
+    case 'meds':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function noteForType(type) {
+  switch (type) {
+    case 'meds':
+      return 'Daily med';
+    case 'water':
+      return 'Hydration';
+    case 'steps':
+      return 'Move';
+    case 'sleep':
+      return 'Rest';
+    case 'caffeine':
+      return 'Coffee';
+    default:
+      return '';
+  }
+}

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -1,0 +1,82 @@
+import { SharedStorage } from './sharedStorage.js';
+import { percent, minutesToHours } from './utils.js';
+
+export function initInsights() {
+  const container = document.getElementById('insights');
+  if (!container) return;
+
+  function render() {
+    const items = computeInsights();
+    container.innerHTML = '';
+    if (!items.length) {
+      const empty = document.createElement('div');
+      empty.className = 'insight-item';
+      empty.innerHTML = `<strong>Everything synced</strong><span>You're meeting today's targets so far.</span>`;
+      container.appendChild(empty);
+      return;
+    }
+
+    items.slice(0, 3).forEach((insight) => {
+      const el = document.createElement('div');
+      el.className = 'insight-item';
+      el.innerHTML = `<strong>${insight.title}</strong><span>${insight.detail}</span>`;
+      container.appendChild(el);
+    });
+  }
+
+  render();
+  SharedStorage.onChange((payload) => {
+    if (!payload || payload.target === 'logs' || payload.target === 'targets') {
+      render();
+    }
+  });
+}
+
+function computeInsights() {
+  const insights = [];
+  const now = new Date();
+  const hour = now.getHours();
+  const today = SharedStorage.aggregateDay(now);
+  const targets = SharedStorage.getTargets();
+  const waterPct = percent(today.water, targets.water || 1);
+  const sleepHours = today.sleep / 60;
+  const caffeine = today.caffeine;
+  const stepsPct = percent(today.steps, targets.steps || 1);
+
+  if (hour >= 18 && waterPct < 60) {
+    insights.push({
+      title: 'Hydration lagging',
+      detail: `Only ${waterPct}% of hydration goal reached. Consider a glass of water to stay on track.`,
+    });
+  }
+
+  if (hour >= 21 && sleepHours < 7) {
+    insights.push({
+      title: 'Prepare for better sleep',
+      detail: `Logged ${minutesToHours(today.sleep)} so far. Aim for ${minutesToHours(targets.sleep)} tonight.`,
+    });
+  }
+
+  if (caffeine > 300) {
+    insights.push({
+      title: 'Caffeine nearing limit',
+      detail: `You've logged ${caffeine} mg today. Slow down intake to avoid restless sleep.`,
+    });
+  }
+
+  if (stepsPct < 50 && hour >= 15) {
+    insights.push({
+      title: 'Movement break suggested',
+      detail: `Only ${stepsPct}% of your steps goal so far. A short walk could keep the streak alive.`,
+    });
+  }
+
+  if (!insights.length && today.meds === 0 && Array.isArray(targets.meds) && targets.meds.length) {
+    insights.push({
+      title: 'Medication reminder',
+      detail: 'No medications logged yet today. Mark as taken once completed.',
+    });
+  }
+
+  return insights;
+}

--- a/assets/js/kpi.js
+++ b/assets/js/kpi.js
@@ -1,0 +1,135 @@
+import { SharedStorage } from './sharedStorage.js';
+import { lazySparkline } from './charts.js';
+import { percent, badgeLabel, statusFromRules, minutesToHours, formatNumber } from './utils.js';
+
+const KPI_GRID_ID = 'kpi-grid';
+
+const KPI_CONFIG = [
+  {
+    id: 'hydration',
+    label: 'Hydration',
+    type: 'water',
+    formatter: (value) => `${formatNumber(value)} ml`,
+    goalFormatter: (goal) => `${formatNumber(goal)} ml`,
+  },
+  {
+    id: 'sleep',
+    label: 'Sleep',
+    type: 'sleep',
+    formatter: (value) => minutesToHours(value),
+    goalFormatter: (goal) => `${minutesToHours(goal)} target`,
+  },
+  {
+    id: 'steps',
+    label: 'Steps',
+    type: 'steps',
+    formatter: (value) => formatNumber(value),
+    goalFormatter: (goal) => `${formatNumber(goal)} goal`,
+  },
+  {
+    id: 'caffeine',
+    label: 'Caffeine',
+    type: 'caffeine',
+    formatter: (value) => `${formatNumber(value)} mg`,
+    goalFormatter: (goal) => `${formatNumber(goal)} mg`,
+  },
+  {
+    id: 'meds',
+    label: 'Meds',
+    type: 'meds',
+    formatter: (value) => `${value} taken`,
+    goalFormatter: (_, context) => `${context?.targetCount || 0} scheduled`,
+  },
+];
+
+export function initKpi() {
+  const grid = document.getElementById(KPI_GRID_ID);
+  if (!grid) return;
+
+  function render() {
+    const targets = SharedStorage.getTargets();
+    const today = SharedStorage.aggregateDay(new Date());
+    const medsTarget = Array.isArray(targets.meds) ? targets.meds.length : 0;
+    const medsTaken = SharedStorage.listLogs({ type: 'meds', since: startOfDayISO(new Date()) }).length;
+    const context = { targetCount: medsTarget, medsTaken, missed: medsTarget > medsTaken };
+
+    grid.innerHTML = '';
+
+    KPI_CONFIG.forEach((config) => {
+      const targetValue = getTargetValue(config.id, targets, context);
+      const totalValue = config.id === 'meds' ? medsTaken : today[config.type] || 0;
+      const status = statusFromRules(config.id === 'hydration' ? 'hydration' : config.id, totalValue, targetValue, context);
+      const badge = badgeLabel(status);
+      const completion = targetValue ? percent(totalValue, targetValue) : 100;
+      const card = document.createElement('article');
+      card.className = 'kpi-card card-hover';
+      if (status === 'on-track' && completion >= 100) {
+        card.classList.add('goal-pulse');
+        setTimeout(() => card.classList.remove('goal-pulse'), 700);
+      }
+
+      const header = document.createElement('header');
+      const title = document.createElement('h3');
+      title.textContent = config.label;
+      const badgeEl = document.createElement('span');
+      badgeEl.className = 'kpi-badge';
+      if (status === 'warning') badgeEl.dataset.state = 'warning';
+      if (status === 'danger') badgeEl.dataset.state = 'danger';
+      badgeEl.textContent = badge;
+      header.append(title, badgeEl);
+
+      const value = document.createElement('div');
+      value.className = 'kpi-value';
+      value.textContent = config.formatter(totalValue, targetValue);
+
+      const progress = document.createElement('div');
+      progress.className = 'kpi-progress';
+      progress.textContent = `${completion}% of ${config.goalFormatter(targetValue, context)}`;
+
+      const sparkline = document.createElement('canvas');
+      sparkline.className = 'sparkline';
+      const series = computeSeries(config.type);
+      lazySparkline(sparkline, series, 'rgba(96, 165, 250, 0.6)');
+
+      card.append(header, value, progress, sparkline);
+      grid.appendChild(card);
+    });
+  }
+
+  render();
+  SharedStorage.onChange(() => render());
+}
+
+function computeSeries(type) {
+  const days = 7;
+  const series = [];
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const date = new Date(Date.now() - i * 86400000);
+    const aggregate = SharedStorage.aggregateDay(date);
+    series.push(aggregate[type] || 0);
+  }
+  return series;
+}
+
+function getTargetValue(id, targets, context) {
+  switch (id) {
+    case 'hydration':
+      return targets.water;
+    case 'sleep':
+      return targets.sleep;
+    case 'steps':
+      return targets.steps;
+    case 'caffeine':
+      return targets.caffeine;
+    case 'meds':
+      return context?.targetCount || 0;
+    default:
+      return 0;
+  }
+}
+
+function startOfDayISO(date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+}

--- a/assets/js/quick-actions.js
+++ b/assets/js/quick-actions.js
@@ -1,0 +1,73 @@
+import { SharedStorage } from './sharedStorage.js';
+import { showToast } from './ui.js';
+
+const ACTIONS = [
+  { id: 'water-250', type: 'water', value: 250, label: '+250 ml', hint: 'Hydration boost' },
+  { id: 'water-500', type: 'water', value: 500, label: '+500 ml', hint: 'Tall glass' },
+  { id: 'steps-1k', type: 'steps', value: 1000, label: '+1k steps', hint: 'Quick walk' },
+  { id: 'sleep-8h', type: 'sleep', value: 480, label: '+8h sleep', hint: 'Log rest' },
+  { id: 'meds', type: 'meds', value: 1, label: 'Take meds', hint: 'Mark taken' },
+];
+
+export function initQuickActions() {
+  const container = document.getElementById('quick-actions');
+  const noteButton = document.getElementById('action-note');
+  if (!container) return;
+
+  container.innerHTML = '';
+  ACTIONS.forEach((action) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'quick-action card-hover card-press';
+    button.dataset.type = action.type;
+    button.dataset.value = action.value;
+    button.innerHTML = `<span>${action.label}</span><small>${action.hint}</small>`;
+    button.addEventListener('click', () => handleAction(action));
+    container.appendChild(button);
+  });
+
+  if (noteButton) {
+    noteButton.addEventListener('click', () => {
+      const note = window.prompt('Add note');
+      if (!note) return;
+      const log = SharedStorage.pushLog('note', null, { note });
+      showToast('Note added', {
+        onUndo: () => SharedStorage.removeLog(log.id),
+      });
+    });
+  }
+
+  window.addEventListener('online', flushQueue);
+  flushQueue();
+}
+
+function handleAction(action) {
+  const payload = { type: action.type, value: action.value };
+  if (navigator.onLine === false) {
+    SharedStorage.addQueue({ kind: 'log', payload });
+    showToast(`${action.label} queued`, {
+      undoLabel: 'Undo',
+      onUndo: () => cancelQueued(payload),
+    });
+    return;
+  }
+  const log = SharedStorage.pushLog(action.type, action.value);
+  showToast(`Added ${action.label}`, {
+    undoLabel: 'Undo',
+    onUndo: () => SharedStorage.removeLog(log.id),
+  });
+}
+
+function cancelQueued(payload) {
+  SharedStorage.removeQueue((item) => item.kind === 'log' && item.payload.type === payload.type && item.payload.value === payload.value);
+}
+
+function flushQueue() {
+  SharedStorage.flushQueue((items) => {
+    items.forEach((item) => {
+      if (item.kind === 'log') {
+        SharedStorage.pushLog(item.payload.type, item.payload.value, { source: 'queue' });
+      }
+    });
+  });
+}

--- a/assets/js/sharedStorage.js
+++ b/assets/js/sharedStorage.js
@@ -1,0 +1,379 @@
+const STORAGE_KEY = 'health2099-db-v1';
+const CHANNEL_NAME = 'health2099';
+const DEFAULT_DB = {
+  version: 1,
+  logs: [],
+  targets: {
+    water: 2500,
+    steps: 8000,
+    sleep: 420,
+    caffeine: 240,
+    meds: [],
+  },
+  settings: {
+    tz: 'Europe/Amsterdam',
+    city: '',
+    deviceBattery: 82,
+    lastDevicePing: null,
+  },
+  queue: [],
+};
+
+const listeners = new Set();
+const channel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel(CHANNEL_NAME) : null;
+
+if (channel) {
+  channel.addEventListener('message', (event) => {
+    if (event?.data?.type === 'sync') {
+      hydrate();
+      emit(event.data.payload);
+    }
+  });
+}
+
+let db = hydrate();
+
+function hydrate() {
+  let parsed;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    parsed = raw ? JSON.parse(raw) : null;
+  } catch (err) {
+    console.warn('[sharedStorage] Failed to parse db', err);
+  }
+  const next = mergeDeep({}, DEFAULT_DB, parsed || {});
+  next.logs = Array.isArray(next.logs)
+    ? next.logs
+        .filter((item) => item && item.id && item.createdAt)
+        .map(normalizeLog)
+        .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+    : [];
+  next.targets = normalizeTargets(next.targets);
+  next.settings = { ...DEFAULT_DB.settings, ...(next.settings || {}) };
+  next.queue = Array.isArray(next.queue) ? next.queue.filter(Boolean) : [];
+  db = next;
+  persist();
+  return next;
+}
+
+function mergeDeep(target, ...sources) {
+  if (!sources.length) return target;
+  const source = sources.shift();
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    });
+  }
+  return mergeDeep(target, ...sources);
+}
+
+function isObject(item) {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+function normalizeLog(log) {
+  const now = new Date();
+  const created = new Date(log.createdAt || log.created_at || now);
+  const updated = new Date(log.updatedAt || log.updated_at || created);
+  const type = typeof log.type === 'string' ? log.type.toLowerCase() : 'generic';
+  return {
+    id: String(log.id || createId('log')),
+    type,
+    value: toNumber(log.value),
+    unit: log.unit || inferUnit(type),
+    note: log.note || '',
+    createdAt: created.toISOString(),
+    updatedAt: updated.toISOString(),
+    source: log.source || 'manual',
+  };
+}
+
+function normalizeTargets(targets) {
+  const next = { ...DEFAULT_DB.targets, ...(targets || {}) };
+  const ensureNumber = (value, fallback) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+  };
+  next.water = ensureNumber(next.water, DEFAULT_DB.targets.water);
+  next.steps = ensureNumber(next.steps, DEFAULT_DB.targets.steps);
+  next.sleep = ensureNumber(next.sleep, DEFAULT_DB.targets.sleep);
+  next.caffeine = ensureNumber(next.caffeine, DEFAULT_DB.targets.caffeine);
+  if (!Array.isArray(next.meds)) next.meds = [];
+  return next;
+}
+
+function inferUnit(type) {
+  switch (type) {
+    case 'water':
+      return 'ml';
+    case 'steps':
+      return 'steps';
+    case 'sleep':
+      return 'min';
+    case 'caffeine':
+      return 'mg';
+    case 'meds':
+      return 'dose';
+    default:
+      return '';
+  }
+}
+
+function toNumber(value) {
+  if (value == null || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function persist() {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: db.version,
+        logs: db.logs,
+        targets: db.targets,
+        settings: db.settings,
+        queue: db.queue,
+      }),
+    );
+  } catch (err) {
+    console.warn('[sharedStorage] Failed to persist db', err);
+  }
+}
+
+function emit(payload) {
+  listeners.forEach((listener) => {
+    try {
+      listener(payload || {});
+    } catch (err) {
+      console.error(err);
+    }
+  });
+}
+
+function notify(payload) {
+  persist();
+  emit(payload);
+  if (channel) {
+    channel.postMessage({ type: 'sync', payload });
+  }
+}
+
+function createLog(type, value, options = {}) {
+  const now = new Date();
+  const tzOffset = now.getTimezoneOffset();
+  const iso = new Date(now.getTime() - tzOffset * 60000).toISOString();
+  const log = normalizeLog({
+    id: options.id,
+    type,
+    value,
+    unit: options.unit,
+    note: options.note || '',
+    createdAt: options.createdAt || iso,
+    updatedAt: options.updatedAt || iso,
+    source: options.source,
+  });
+  return log;
+}
+
+function pushLog(type, value, options = {}) {
+  const log = createLog(type, value, options);
+  db.logs = [log, ...db.logs].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  db.settings.lastDevicePing = log.createdAt;
+  notify({ target: 'logs', action: 'push', log });
+  return log;
+}
+
+function updateLog(id, updates) {
+  let updated;
+  db.logs = db.logs.map((log) => {
+    if (log.id !== id) return log;
+    updated = { ...log, ...updates, updatedAt: new Date().toISOString() };
+    return normalizeLog(updated);
+  });
+  if (updated) {
+    notify({ target: 'logs', action: 'update', log: updated });
+  }
+  return updated;
+}
+
+function removeLog(id) {
+  const removed = db.logs.find((log) => log.id === id);
+  db.logs = db.logs.filter((log) => log.id !== id);
+  if (removed) {
+    notify({ target: 'logs', action: 'remove', log: removed });
+  }
+  return removed;
+}
+
+function listLogs({ type, limit, since } = {}) {
+  let items = [...db.logs];
+  if (type) {
+    items = items.filter((log) => log.type === type);
+  }
+  if (since) {
+    const sinceDate = new Date(since);
+    items = items.filter((log) => new Date(log.createdAt) >= sinceDate);
+  }
+  if (typeof limit === 'number') {
+    items = items.slice(0, limit);
+  }
+  return items;
+}
+
+function getTargets() {
+  return { ...db.targets };
+}
+
+function setTargets(nextTargets) {
+  db.targets = normalizeTargets({ ...db.targets, ...nextTargets });
+  notify({ target: 'targets', action: 'set', targets: db.targets });
+  return getTargets();
+}
+
+function getSettings() {
+  return { ...db.settings };
+}
+
+function setSettings(partial) {
+  db.settings = { ...db.settings, ...(partial || {}) };
+  notify({ target: 'settings', action: 'set', settings: db.settings });
+  return getSettings();
+}
+
+function onChange(listener) {
+  if (typeof listener !== 'function') return () => {};
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function addQueue(action) {
+  db.queue = [
+    ...db.queue,
+    {
+      id: createId('queue'),
+      createdAt: new Date().toISOString(),
+      ...action,
+    },
+  ];
+  notify({ target: 'queue', action: 'push' });
+}
+
+function flushQueue(flushFn) {
+  if (!db.queue.length) return Promise.resolve([]);
+  const items = [...db.queue];
+  db.queue = [];
+  notify({ target: 'queue', action: 'flush' });
+  if (typeof flushFn === 'function') {
+    return Promise.resolve(flushFn(items));
+  }
+  return Promise.resolve(items);
+}
+
+function removeQueue(predicate) {
+  if (typeof predicate !== 'function') return;
+  db.queue = db.queue.filter((item) => !predicate(item));
+  notify({ target: 'queue', action: 'remove' });
+}
+
+function recentLogs(hours = 24) {
+  const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
+  return listLogs({ since: cutoff.toISOString() });
+}
+
+function aggregateDay(date = new Date()) {
+  const start = startOfDay(date);
+  const end = endOfDay(date);
+  return aggregateRange(start, end);
+}
+
+function aggregateRange(start, end) {
+  const result = {
+    water: 0,
+    steps: 0,
+    sleep: 0,
+    caffeine: 0,
+    meds: 0,
+  };
+  const startTime = start.getTime();
+  const endTime = end.getTime();
+  db.logs.forEach((log) => {
+    const time = new Date(log.createdAt).getTime();
+    if (time < startTime || time > endTime) return;
+    switch (log.type) {
+      case 'water':
+        result.water += log.value || 0;
+        break;
+      case 'steps':
+        result.steps += log.value || 0;
+        break;
+      case 'sleep':
+        result.sleep += log.value || 0;
+        break;
+      case 'caffeine':
+        result.caffeine += log.value || 0;
+        break;
+      case 'meds':
+        result.meds += 1;
+        break;
+      default:
+        break;
+    }
+  });
+  return result;
+}
+
+function streaks(days = 14) {
+  const dayMap = new Map();
+  for (let i = 0; i < days; i += 1) {
+    const day = startOfDay(new Date(Date.now() - i * 86400000));
+    const key = day.toISOString();
+    dayMap.set(key, aggregateDay(day));
+  }
+  return dayMap;
+}
+
+function startOfDay(date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function endOfDay(date) {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+export const SharedStorage = {
+  listLogs,
+  pushLog,
+  updateLog,
+  removeLog,
+  recentLogs,
+  aggregateDay,
+  aggregateRange,
+  streaks,
+  getTargets,
+  setTargets,
+  getSettings,
+  setSettings,
+  onChange,
+  addQueue,
+  flushQueue,
+  removeQueue,
+  createLog,
+};
+
+function createId(prefix = 'id') {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -1,0 +1,120 @@
+import { SharedStorage } from './sharedStorage.js';
+
+export function initSidebar() {
+  const waterInput = document.getElementById('target-water');
+  const stepsInput = document.getElementById('target-steps');
+  const sleepInput = document.getElementById('target-sleep');
+  const caffeineInput = document.getElementById('target-caffeine');
+  const medsList = document.getElementById('meds-list');
+  const addMedButton = document.getElementById('add-med');
+  if (!waterInput || !stepsInput || !sleepInput || !caffeineInput || !medsList) return;
+
+  const inputs = [waterInput, stepsInput, sleepInput, caffeineInput];
+  const debouncedSave = debounce(saveTargets, 400);
+
+  function render() {
+    const targets = SharedStorage.getTargets();
+    waterInput.value = targets.water;
+    stepsInput.value = targets.steps;
+    sleepInput.value = targets.sleep;
+    caffeineInput.value = targets.caffeine;
+
+    medsList.innerHTML = '';
+    const meds = Array.isArray(targets.meds) ? targets.meds : [];
+    const takenLogs = SharedStorage.listLogs({ type: 'meds', since: startOfDayISO(new Date()) });
+
+    meds.forEach((med) => {
+      const item = document.createElement('div');
+      item.className = 'meds-item';
+      const label = document.createElement('label');
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = takenLogs.some((log) => log.note === med.name);
+      checkbox.addEventListener('change', () => toggleMed(med, checkbox.checked));
+      const span = document.createElement('span');
+      span.textContent = med.name;
+      span.tabIndex = 0;
+      span.addEventListener('dblclick', () => editMedName(med));
+      span.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          editMedName(med);
+        }
+      });
+      label.append(checkbox, span);
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.textContent = 'Remove';
+      removeBtn.className = 'card-press';
+      removeBtn.addEventListener('click', () => removeMed(med.id));
+      item.append(label, removeBtn);
+      medsList.appendChild(item);
+    });
+  }
+
+  inputs.forEach((input) => {
+    input.addEventListener('input', () => debouncedSave(inputs));
+  });
+
+  if (addMedButton) {
+    addMedButton.addEventListener('click', () => {
+      const name = window.prompt('Medication name');
+      if (!name) return;
+      const targets = SharedStorage.getTargets();
+      const meds = Array.isArray(targets.meds) ? [...targets.meds] : [];
+      meds.push({ id: crypto.randomUUID(), name });
+      SharedStorage.setTargets({ ...targets, meds });
+    });
+  }
+
+  render();
+  SharedStorage.onChange((payload) => {
+    if (!payload || payload.target === 'targets' || payload.target === 'logs') {
+      render();
+    }
+  });
+}
+
+function saveTargets(inputs) {
+  const [water, steps, sleep, caffeine] = inputs.map((input) => Number(input.value || 0));
+  SharedStorage.setTargets({ water, steps, sleep, caffeine });
+}
+
+function toggleMed(med, checked) {
+  if (checked) {
+    SharedStorage.pushLog('meds', 1, { note: med.name });
+  } else {
+    const todays = SharedStorage.listLogs({ type: 'meds', since: startOfDayISO(new Date()) });
+    const targetLog = todays.find((log) => log.note === med.name);
+    if (targetLog) {
+      SharedStorage.removeLog(targetLog.id);
+    }
+  }
+}
+
+function editMedName(med) {
+  const name = window.prompt('Update medication name', med.name);
+  if (!name) return;
+  const targets = SharedStorage.getTargets();
+  const meds = Array.isArray(targets.meds) ? targets.meds.map((item) => (item.id === med.id ? { ...item, name } : item)) : [];
+  SharedStorage.setTargets({ ...targets, meds });
+}
+
+function removeMed(id) {
+  const targets = SharedStorage.getTargets();
+  const meds = Array.isArray(targets.meds) ? targets.meds.filter((med) => med.id !== id) : [];
+  SharedStorage.setTargets({ ...targets, meds });
+}
+
+function startOfDayISO(date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
+function debounce(fn, delay) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}

--- a/assets/js/streaks.js
+++ b/assets/js/streaks.js
@@ -1,0 +1,114 @@
+import { SharedStorage } from './sharedStorage.js';
+import { minutesToHours } from './utils.js';
+
+let lastStreaks = { water: 0, steps: 0, sleep: 0 };
+
+export function initStreaks() {
+  const list = document.getElementById('streak-list');
+  const badgeContainer = document.getElementById('badge-collection');
+  if (!list || !badgeContainer) return;
+
+  function render() {
+    const targets = SharedStorage.getTargets();
+    const streakMap = SharedStorage.streaks(14);
+    const entries = Array.from(streakMap.entries());
+    const metrics = [
+      { id: 'water', label: 'Hydration streak', target: targets.water, formatter: (value) => `${value} ml` },
+      { id: 'steps', label: 'Steps streak', target: targets.steps, formatter: (value) => `${value} steps` },
+      { id: 'sleep', label: 'Sleep streak', target: targets.sleep, formatter: (value) => minutesToHours(value) },
+    ];
+
+    list.innerHTML = '';
+    const newStreaks = {};
+
+    metrics.forEach((metric) => {
+      const streakValue = computeStreak(entries, metric.id, metric.target);
+      newStreaks[metric.id] = streakValue;
+      const todayValue = entries.length ? entries[0][1][metric.id] : 0;
+      const row = document.createElement('div');
+      row.className = 'streak card-hover';
+      row.innerHTML = `
+        <span aria-hidden="true">${metricIcon(metric.id)}</span>
+        <div>
+          <strong>${metric.label}</strong>
+          <div class="timeline-meta">${streakValue} day streak · Today ${metric.formatter(todayValue)}</div>
+        </div>
+        <span>${badgeLabel(streakValue)}</span>
+      `;
+      if (streakValue > (lastStreaks[metric.id] || 0)) {
+        row.classList.add('goal-pulse');
+      }
+      list.appendChild(row);
+    });
+
+    badgeContainer.innerHTML = '';
+    const badges = buildBadges(newStreaks);
+    badges.forEach((badge) => {
+      const chip = document.createElement('span');
+      chip.className = 'badge-chip badge-animate';
+      chip.textContent = badge;
+      badgeContainer.appendChild(chip);
+    });
+
+    lastStreaks = newStreaks;
+  }
+
+  render();
+  SharedStorage.onChange((payload) => {
+    if (!payload || payload.target === 'logs' || payload.target === 'targets') {
+      render();
+    }
+  });
+}
+
+function computeStreak(entries, metric, target) {
+  let streak = 0;
+  for (let i = 0; i < entries.length; i += 1) {
+    const value = entries[i][1][metric] || 0;
+    const success = metric === 'caffeine' ? value <= target : value >= target;
+    if (success) {
+      streak += 1;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+function buildBadges(streaks) {
+  const badges = [];
+  Object.entries(streaks).forEach(([metric, value]) => {
+    if (value >= 14) {
+      badges.push(`${titleCase(metric)} Ascendant`);
+    } else if (value >= 7) {
+      badges.push(`${titleCase(metric)} Guardian`);
+    } else if (value >= 3) {
+      badges.push(`${titleCase(metric)} Builder`);
+    }
+  });
+  return badges;
+}
+
+function badgeLabel(streak) {
+  if (streak >= 14) return 'Legendary';
+  if (streak >= 7) return 'Great';
+  if (streak >= 3) return 'Building';
+  return 'Getting started';
+}
+
+function metricIcon(metric) {
+  switch (metric) {
+    case 'water':
+      return '💧';
+    case 'steps':
+      return '🔥';
+    case 'sleep':
+      return '🌙';
+    default:
+      return '⭐';
+  }
+}
+
+function titleCase(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/assets/js/summary-header.js
+++ b/assets/js/summary-header.js
@@ -1,0 +1,54 @@
+import { SharedStorage } from './sharedStorage.js';
+import { formatDateRange } from './utils.js';
+
+const HEADER_ID = 'summary-header';
+
+export function initHeader() {
+  const container = document.getElementById(HEADER_ID);
+  if (!container) return;
+
+  function render() {
+    const settings = SharedStorage.getSettings();
+    const now = new Date();
+    const dateLabel = formatDateRange(now);
+    const city = settings.city ? ` · ${settings.city}` : '';
+    const battery = settings.deviceBattery ?? 0;
+    const lastPing = settings.lastDevicePing ? new Date(settings.lastDevicePing) : null;
+    const status = computeDeviceStatus(lastPing);
+    container.innerHTML = `
+      <div class="summary-header__inner">
+        <div class="summary-header__meta">
+          <span class="snapshot-pill">Wellness snapshot — <strong>${dateLabel}</strong>${city}</span>
+          <span class="snapshot-pill">Battery <strong>${battery}%</strong></span>
+        </div>
+        <div class="summary-header__status">
+          <div class="device-status" data-state="${status.color}">
+            <span aria-hidden="true">${status.icon}</span>
+            <span>${status.label}</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  render();
+  SharedStorage.onChange((payload) => {
+    if (!payload || payload.target === 'logs' || payload.target === 'settings') {
+      render();
+    }
+  });
+}
+
+function computeDeviceStatus(lastPing) {
+  if (!lastPing) {
+    return { color: 'red', label: 'Device offline', icon: '⚠️' };
+  }
+  const diffMinutes = Math.floor((Date.now() - lastPing.getTime()) / 60000);
+  if (diffMinutes <= 5) {
+    return { color: 'green', label: 'Device status · Fresh', icon: '🟢' };
+  }
+  if (diffMinutes <= 10) {
+    return { color: 'yellow', label: 'Device status · Slight delay', icon: '🟡' };
+  }
+  return { color: 'red', label: 'Device status · Needs sync', icon: '🔴' };
+}

--- a/assets/js/summary-page.js
+++ b/assets/js/summary-page.js
@@ -1,0 +1,28 @@
+import { initHeader } from './summary-header.js';
+import { initKpi } from './kpi.js';
+import { initQuickActions } from './quick-actions.js';
+import { initTimeline } from './timeline.js';
+import { initInsights } from './insights.js';
+import { initStreaks } from './streaks.js';
+import { initSidebar } from './sidebar.js';
+import { initDevSeed } from './dev-seed.js';
+import './ui.js';
+
+function ready(callback) {
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    callback();
+  } else {
+    document.addEventListener('DOMContentLoaded', callback, { once: true });
+  }
+}
+
+ready(() => {
+  initHeader();
+  initKpi();
+  initQuickActions();
+  initTimeline();
+  initInsights();
+  initStreaks();
+  initSidebar();
+  initDevSeed();
+});

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -1,0 +1,179 @@
+import { SharedStorage } from './sharedStorage.js';
+import { iconForType, formatTime, isoToDate, unitLabel } from './utils.js';
+
+const TIMELINE_LIST_ID = 'timeline-list';
+
+export function initTimeline() {
+  const list = document.getElementById(TIMELINE_LIST_ID);
+  const headerCount = document.getElementById('timeline-count');
+  if (!list) return;
+
+  function render() {
+    const logs = SharedStorage.listLogs({ since: startOfDayISO(new Date()) });
+    list.innerHTML = '';
+    if (headerCount) {
+      headerCount.textContent = `${logs.length} events`;
+    }
+    if (!logs.length) {
+      list.innerHTML = `<div class="timeline-empty">No activity yet today.<br /><button type="button" id="timeline-empty-add">Add hydration</button></div>`;
+      const emptyBtn = document.getElementById('timeline-empty-add');
+      if (emptyBtn) {
+        emptyBtn.addEventListener('click', () => {
+          SharedStorage.pushLog('water', 250);
+        });
+      }
+      return;
+    }
+
+    logs.forEach((log) => {
+      const item = document.createElement('article');
+      item.className = 'timeline-item card-hover';
+      item.dataset.type = log.type;
+      item.tabIndex = 0;
+      item.addEventListener('dblclick', () => openEditor(item, log, render));
+      item.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          openEditor(item, log, render);
+        }
+      });
+
+      const icon = document.createElement('div');
+      icon.className = 'timeline-icon';
+      icon.textContent = iconForType(log.type);
+      icon.setAttribute('aria-hidden', 'true');
+
+      const content = document.createElement('div');
+      content.className = 'timeline-content';
+
+      const heading = document.createElement('strong');
+      heading.textContent = formatValue(log);
+      const meta = document.createElement('span');
+      meta.className = 'timeline-meta';
+      meta.textContent = `${log.type} · ${formatTime(isoToDate(log.createdAt))}`;
+      content.append(heading, meta);
+
+      if (log.note) {
+        const note = document.createElement('span');
+        note.className = 'timeline-note';
+        note.textContent = log.note;
+        content.appendChild(note);
+      }
+
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'card-press';
+      editBtn.textContent = 'Edit';
+      editBtn.addEventListener('click', () => openEditor(item, log, render));
+
+      item.append(icon, content, editBtn);
+      list.appendChild(item);
+    });
+  }
+
+  render();
+  SharedStorage.onChange((payload) => {
+    if (!payload || payload.target === 'logs') {
+      render();
+    }
+  });
+}
+
+function openEditor(container, log, onComplete) {
+  container.innerHTML = '';
+  container.classList.add('timeline-editable');
+
+  const form = document.createElement('form');
+  form.className = 'timeline-edit-form';
+
+  const valueWrap = document.createElement('div');
+  const valueLabel = document.createElement('label');
+  valueLabel.textContent = 'Value';
+  valueLabel.className = 'visually-hidden';
+  const valueInput = document.createElement('input');
+  valueInput.type = 'number';
+  valueInput.value = log.value ?? 0;
+  valueInput.min = 0;
+  if (log.value == null) {
+    valueInput.disabled = true;
+  }
+  valueWrap.append(valueLabel, valueInput);
+
+  const typeWrap = document.createElement('div');
+  const typeLabel = document.createElement('label');
+  typeLabel.textContent = 'Type';
+  typeLabel.className = 'visually-hidden';
+  const typeSelect = document.createElement('select');
+  ['water', 'steps', 'sleep', 'caffeine', 'meds', 'note'].forEach((type) => {
+    const option = document.createElement('option');
+    option.value = type;
+    option.textContent = type;
+    if (type === log.type) option.selected = true;
+    typeSelect.appendChild(option);
+  });
+  typeWrap.append(typeLabel, typeSelect);
+
+  const noteWrap = document.createElement('div');
+  const noteLabel = document.createElement('label');
+  noteLabel.textContent = 'Note';
+  noteLabel.className = 'visually-hidden';
+  const noteInput = document.createElement('textarea');
+  noteInput.value = log.note || '';
+  noteWrap.append(noteLabel, noteInput);
+
+  const actions = document.createElement('div');
+  actions.className = 'timeline-actions';
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'submit';
+  saveBtn.textContent = 'Save';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.textContent = 'Cancel';
+  const deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.textContent = 'Delete';
+  deleteBtn.addEventListener('click', () => {
+    SharedStorage.removeLog(log.id);
+  });
+  cancelBtn.addEventListener('click', () => {
+    if (typeof onComplete === 'function') onComplete();
+  });
+  actions.append(cancelBtn, saveBtn, deleteBtn);
+
+  form.append(valueWrap, typeWrap, noteWrap, actions);
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const newType = typeSelect.value;
+    const newValue = valueInput.disabled ? null : Number(valueInput.value || 0);
+    SharedStorage.updateLog(log.id, {
+      type: newType,
+      value: newValue,
+      note: noteInput.value,
+    });
+    if (typeof onComplete === 'function') onComplete();
+  });
+
+  container.appendChild(form);
+
+  typeSelect.addEventListener('change', () => {
+    if (typeSelect.value === 'note') {
+      valueInput.disabled = true;
+      valueInput.value = '';
+    } else {
+      valueInput.disabled = false;
+    }
+  });
+}
+
+function formatValue(log) {
+  if (log.value == null) {
+    return log.note || log.type;
+  }
+  const unit = unitLabel(log.type);
+  return `${log.value} ${unit}`;
+}
+
+function startOfDayISO(date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+}

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -1,0 +1,47 @@
+const TOAST_DURATION = 6000;
+
+export function createToastContainer() {
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container';
+    container.setAttribute('aria-live', 'polite');
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+export function showToast(message, options = {}) {
+  const container = createToastContainer();
+  const toast = document.createElement('div');
+  toast.className = 'toast card-hover';
+  toast.tabIndex = 0;
+
+  const messageEl = document.createElement('div');
+  messageEl.textContent = message;
+  toast.appendChild(messageEl);
+
+  if (typeof options.onUndo === 'function') {
+    const undoBtn = document.createElement('button');
+    undoBtn.type = 'button';
+    undoBtn.className = 'card-press';
+    undoBtn.textContent = options.undoLabel || 'Undo';
+    let undone = false;
+    undoBtn.addEventListener('click', () => {
+      if (undone) return;
+      undone = true;
+      options.onUndo();
+      removeToast(toast);
+    });
+    toast.appendChild(undoBtn);
+  }
+
+  container.appendChild(toast);
+  setTimeout(() => removeToast(toast), options.duration || TOAST_DURATION);
+  return toast;
+}
+
+function removeToast(toast) {
+  if (!toast?.parentElement) return;
+  toast.parentElement.removeChild(toast);
+}

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,0 +1,122 @@
+export function formatDateRange(date) {
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+  return formatter.format(date);
+}
+
+export function formatTime(date) {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+export function minutesToHours(minutes) {
+  if (!minutes) return '0h';
+  const hours = minutes / 60;
+  return `${(Math.round(hours * 10) / 10).toFixed(1)}h`;
+}
+
+export function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function percent(value, target) {
+  if (!target) return 0;
+  return clamp(Math.round((value / target) * 100), 0, 300);
+}
+
+export function statusFromRules(type, total, target, context = {}) {
+  switch (type) {
+    case 'hydration': {
+      if (total >= target) return 'on-track';
+      if (percent(total, target) < 60) return 'warning';
+      return 'progress';
+    }
+    case 'sleep': {
+      const hours = total / 60;
+      if (hours >= 7) return 'on-track';
+      if (hours < 6) return 'warning';
+      return 'progress';
+    }
+    case 'steps': {
+      if (total >= 8000) return 'on-track';
+      if (total < 5000) return 'warning';
+      return 'progress';
+    }
+    case 'caffeine': {
+      if (total > 300) return 'warning';
+      if (total > target) return 'warning';
+      return 'on-track';
+    }
+    case 'meds': {
+      if (context.missed) return 'danger';
+      return context.medsTaken ? 'on-track' : 'progress';
+    }
+    default:
+      return 'progress';
+  }
+}
+
+export function badgeLabel(status) {
+  switch (status) {
+    case 'on-track':
+      return 'On track';
+    case 'warning':
+      return 'Warning';
+    case 'danger':
+      return 'Missed';
+    default:
+      return 'In progress';
+  }
+}
+
+export function iconForType(type) {
+  switch (type) {
+    case 'water':
+      return '💧';
+    case 'steps':
+      return '👟';
+    case 'sleep':
+      return '🌙';
+    case 'caffeine':
+      return '☕';
+    case 'meds':
+      return '💊';
+    default:
+      return '🧠';
+  }
+}
+
+export function unitLabel(type) {
+  switch (type) {
+    case 'water':
+      return 'ml';
+    case 'steps':
+      return 'steps';
+    case 'sleep':
+      return 'min';
+    case 'caffeine':
+      return 'mg';
+    default:
+      return '';
+  }
+}
+
+export function isoToDate(iso) {
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+export function pluralize(value, unit) {
+  if (value === 1) return `${value} ${unit}`;
+  return `${value} ${unit}s`;
+}
+
+export function formatNumber(num, options = {}) {
+  const formatter = new Intl.NumberFormat(undefined, options);
+  return formatter.format(num || 0);
+}


### PR DESCRIPTION
## Summary
- restyled Summary.html into a Revolut Dark-inspired wellness console with header, KPI grid, timeline, insights, streaks, and sidebar targets
- introduced theme token variables and premium glassmorphism styling with supporting animations, timeline, and badge styles
- implemented shared storage module, interactive widgets (KPIs, quick actions, timeline editing, insights, streaks, sidebar targets), lazy sparkline charts, toast system, and demo data seeding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6b5fa45988332a4fce9280471745c