### PR TITLE
Add summary hero KPI with timezone-aware ranges

### DIFF
--- a/assets/css/summary.css
+++ b/assets/css/summary.css
@@ -51,6 +51,14 @@
   gap: 1.5rem;
 }
 
+.summary-header__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .summary-header::after {
   content: "";
   position: absolute;
@@ -77,6 +85,235 @@
 .summary-header__status {
   display: flex;
   align-items: center;
+}
+
+.hero-kpi {
+  display: grid;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 2vw, 2.25rem);
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(2, 6, 23, 0.55), rgba(15, 23, 42, 0.65));
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-kpi::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, rgba(59, 130, 246, 0.28), transparent 60%),
+    radial-gradient(circle at 85% 0%, rgba(8, 145, 178, 0.24), transparent 60%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.hero-kpi__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-kpi__header h1 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: var(--text);
+}
+
+.hero-kpi__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero-kpi__filters {
+  display: inline-flex;
+  gap: 0.35rem;
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  border-radius: 999px;
+  padding: 0.3rem;
+}
+
+.hero-kpi__filter {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 200ms ease, color 200ms ease, box-shadow 200ms ease;
+}
+
+.hero-kpi__filter:hover,
+.hero-kpi__filter:focus-visible {
+  background: rgba(96, 165, 250, 0.2);
+  color: var(--text);
+  outline: none;
+}
+
+.hero-kpi__filter.is-active {
+  background: linear-gradient(90deg, rgba(96, 165, 250, 0.95), rgba(14, 165, 233, 0.9));
+  color: #0f172a;
+  box-shadow: 0 6px 18px rgba(37, 99, 235, 0.35);
+}
+
+.hero-kpi__body {
+  display: grid;
+  gap: 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+@media (min-width: 720px) {
+  .hero-kpi__body {
+    grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.55fr);
+    align-items: stretch;
+  }
+}
+
+.hero-kpi__score {
+  display: grid;
+  gap: 0.6rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(2, 6, 23, 0.6);
+  border: 1px solid rgba(96, 165, 250, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.hero-kpi__label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.hero-kpi__value {
+  font-size: clamp(2.4rem, 5vw, 3.25rem);
+  font-weight: 700;
+  color: var(--text);
+}
+
+.hero-kpi__delta {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero-kpi__delta[data-trend='up'] {
+  color: var(--ok);
+}
+
+.hero-kpi__delta[data-trend='down'] {
+  color: var(--danger);
+}
+
+.hero-kpi__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.hero-kpi__item {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  transition: border-color 200ms ease, transform 200ms ease;
+}
+
+.hero-kpi__item:hover {
+  transform: translateY(-2px);
+}
+
+.hero-kpi__item-top {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.hero-kpi__icon {
+  font-size: 1.35rem;
+}
+
+.hero-kpi__text {
+  flex: 1;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hero-kpi__item-label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.hero-kpi__item-values {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.hero-kpi__badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.18);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.hero-kpi__badge[data-state='warning'] {
+  background: rgba(250, 204, 21, 0.18);
+  color: var(--warn);
+}
+
+.hero-kpi__badge[data-state='danger'] {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--danger);
+}
+
+.hero-kpi__meter {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  overflow: hidden;
+}
+
+.hero-kpi__meter-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(96, 165, 250, 0.95), rgba(14, 165, 233, 0.9));
+  transition: width 280ms ease;
+}
+
+.hero-kpi__item[data-state='warning'] .hero-kpi__meter-fill {
+  background: linear-gradient(90deg, rgba(250, 204, 21, 0.65), rgba(252, 211, 77, 0.75));
+}
+
+.hero-kpi__item[data-state='danger'] .hero-kpi__meter-fill {
+  background: linear-gradient(90deg, rgba(248, 113, 113, 0.75), rgba(239, 68, 68, 0.8));
+}
+
+.hero-kpi__item-foot {
+  font-size: 0.8rem;
+  color: var(--muted);
 }
 
 .snapshot-pill {

--- a/assets/js/hero-kpi.js
+++ b/assets/js/hero-kpi.js
@@ -1,0 +1,344 @@
+import { SharedStorage } from './sharedStorage.js';
+import { badgeLabel, formatNumber, minutesToHours, percent, statusFromRules } from './utils.js';
+
+const HERO_ID = 'hero-kpi';
+
+const METRICS = [
+  {
+    id: 'water',
+    label: 'Hydration',
+    icon: '💧',
+    targetKey: 'water',
+    statusType: 'hydration',
+    better: 'high',
+    formatAverage: (value) => `${formatNumber(Math.round(value))} ml avg`,
+    formatTarget: (target) => `${formatNumber(target)} ml target`,
+    formatTotal: (total, days) => hydrationTotalLabel(total, days),
+  },
+  {
+    id: 'sleep',
+    label: 'Sleep',
+    icon: '🌙',
+    targetKey: 'sleep',
+    statusType: 'sleep',
+    better: 'high',
+    formatAverage: (value) => `${minutesToHours(value)} avg`,
+    formatTarget: (target) => `${minutesToHours(target)} target`,
+    formatTotal: (total, days) => sleepTotalLabel(total, days),
+  },
+  {
+    id: 'steps',
+    label: 'Steps',
+    icon: '👟',
+    targetKey: 'steps',
+    statusType: 'steps',
+    better: 'high',
+    formatAverage: (value) => `${formatNumber(Math.round(value))} steps avg`,
+    formatTarget: (target) => `${formatNumber(target)} goal`,
+    formatTotal: (total, days) => stepsTotalLabel(total, days),
+  },
+  {
+    id: 'caffeine',
+    label: 'Caffeine',
+    icon: '☕',
+    targetKey: 'caffeine',
+    statusType: 'caffeine',
+    better: 'low',
+    formatAverage: (value) => `${formatNumber(Math.round(value))} mg avg`,
+    formatTarget: (target) => `${formatNumber(target)} mg ceiling`,
+    formatTotal: (total, days) => caffeineTotalLabel(total, days),
+  },
+];
+
+const RANGE_CONFIG = {
+  today: { key: 'today', days: 1, label: 'Today', previousLabel: 'yesterday' },
+  '7d': { key: '7d', days: 7, label: 'Last 7 days', previousLabel: 'previous 7 days' },
+  '30d': { key: '30d', days: 30, label: 'Last 30 days', previousLabel: 'previous 30 days' },
+};
+
+export function initHeroKpi() {
+  let container = document.getElementById(HERO_ID);
+  if (!container) return;
+
+  const list = container.querySelector('#hero-kpi-list');
+  const filters = Array.from(container.querySelectorAll('[data-range]'));
+  if (list && list.children.length === 0) {
+    METRICS.forEach((metric) => {
+      const item = document.createElement('li');
+      item.className = 'hero-kpi__item';
+      item.dataset.type = metric.id;
+      item.innerHTML = `
+        <div class="hero-kpi__item-top">
+          <span class="hero-kpi__icon" aria-hidden="true">${metric.icon}</span>
+          <div class="hero-kpi__text">
+            <span class="hero-kpi__item-label">${metric.label}</span>
+            <span class="hero-kpi__item-values">
+              <span data-value>—</span>
+              <span data-target>—</span>
+            </span>
+          </div>
+          <span class="hero-kpi__badge" data-badge>—</span>
+        </div>
+        <div class="hero-kpi__meter">
+          <div class="hero-kpi__meter-fill" data-progress></div>
+        </div>
+        <div class="hero-kpi__item-foot">
+          <span data-detail>—</span>
+        </div>
+      `;
+      list.appendChild(item);
+    });
+  }
+
+  const state = { range: 'today' };
+
+  function updateFilters(rangeKey) {
+    filters.forEach((button) => {
+      const isActive = button.dataset.range === rangeKey;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  function render() {
+    container = document.getElementById(HERO_ID);
+    if (!container) return;
+
+    const currentList = container.querySelector('#hero-kpi-list');
+    const currentScore = container.querySelector('#hero-kpi-score');
+    const currentDelta = container.querySelector('#hero-kpi-delta');
+    const currentCaption = container.querySelector('#hero-kpi-caption');
+    const tz = resolveTimezone();
+    const range = resolveRange(state.range, tz);
+    const totals = SharedStorage.aggregateRange(range.start, range.end);
+    const targets = SharedStorage.getTargets();
+
+    const metricPayloads = METRICS.map((metric) => {
+      const total = totals[metric.id] || 0;
+      const dailyTarget = targets[metric.targetKey] || 0;
+      const aggregateTarget = dailyTarget * range.days;
+      const progressPercent = aggregateTarget ? percent(total, aggregateTarget) : 0;
+      const averageValue = range.days > 0 ? total / range.days : 0;
+      const completion = metric.better === 'low'
+        ? Math.max(0, 100 - Math.min(100, progressPercent))
+        : Math.min(100, progressPercent);
+      const status = statusFromRules(metric.statusType, averageValue, dailyTarget, {
+        rangeDays: range.days,
+      });
+      return {
+        id: metric.id,
+        average: metric.formatAverage(averageValue),
+        target: metric.formatTarget(dailyTarget),
+        detail: metric.formatTotal(total, range.days),
+        badge: badgeLabel(status),
+        state: status,
+        progress: Math.max(0, Math.min(100, progressPercent)),
+        completion,
+      };
+    });
+
+    const completionValues = metricPayloads
+      .map((metric) => metric.completion)
+      .filter((value) => Number.isFinite(value));
+    const score = completionValues.length
+      ? Math.round(completionValues.reduce((sum, value) => sum + value, 0) / completionValues.length)
+      : 0;
+
+    const previousRange = resolvePreviousRange(range, tz);
+    let deltaInfo = null;
+    if (previousRange) {
+      const previousTotals = SharedStorage.aggregateRange(previousRange.start, previousRange.end);
+      const previousCompletions = METRICS.map((metric) => {
+        const total = previousTotals[metric.id] || 0;
+        const dailyTarget = targets[metric.targetKey] || 0;
+        const aggregateTarget = dailyTarget * previousRange.days;
+        const progressPercent = aggregateTarget ? percent(total, aggregateTarget) : 0;
+        return metric.better === 'low'
+          ? Math.max(0, 100 - Math.min(100, progressPercent))
+          : Math.min(100, progressPercent);
+      }).filter((value) => Number.isFinite(value));
+      if (previousCompletions.length) {
+        const prevScore = Math.round(
+          previousCompletions.reduce((sum, value) => sum + value, 0) / previousCompletions.length,
+        );
+        deltaInfo = {
+          delta: score - prevScore,
+          label: previousRange.label,
+        };
+      }
+    }
+
+    if (currentScore) {
+      currentScore.textContent = `${score}%`;
+    }
+
+    if (currentDelta) {
+      if (deltaInfo && Number.isFinite(deltaInfo.delta)) {
+        const rounded = Math.round(deltaInfo.delta);
+        if (Math.abs(rounded) < 1) {
+          currentDelta.textContent = `Level with ${deltaInfo.label}`;
+          currentDelta.dataset.trend = 'flat';
+        } else {
+          const sign = rounded > 0 ? '+' : '';
+          currentDelta.textContent = `${sign}${rounded}% vs ${deltaInfo.label}`;
+          currentDelta.dataset.trend = rounded > 0 ? 'up' : 'down';
+        }
+      } else {
+        currentDelta.textContent = 'Trend data unavailable';
+        currentDelta.dataset.trend = 'flat';
+      }
+    }
+
+    if (currentCaption) {
+      currentCaption.textContent = `${range.label} · TZ ${formatTimezoneLabel(tz)}`;
+    }
+
+    if (currentList) {
+      metricPayloads.forEach((payload) => {
+        const item = currentList.querySelector(`[data-type="${payload.id}"]`);
+        if (!item) return;
+        item.dataset.state = payload.state;
+        const valueEl = item.querySelector('[data-value]');
+        const targetEl = item.querySelector('[data-target]');
+        const detailEl = item.querySelector('[data-detail]');
+        const badgeEl = item.querySelector('[data-badge]');
+        const progressEl = item.querySelector('[data-progress]');
+        if (valueEl) valueEl.textContent = payload.average;
+        if (targetEl) targetEl.textContent = payload.target;
+        if (detailEl) detailEl.textContent = payload.detail;
+        if (badgeEl) {
+          badgeEl.textContent = payload.badge;
+          badgeEl.dataset.state = payload.state;
+        }
+        if (progressEl) {
+          progressEl.style.width = `${payload.progress}%`;
+        }
+      });
+    }
+  }
+
+  filters.forEach((button) => {
+    button.addEventListener('click', () => {
+      const { range } = button.dataset;
+      if (!range || range === state.range) return;
+      state.range = range;
+      updateFilters(state.range);
+      render();
+    });
+  });
+
+  updateFilters(state.range);
+  render();
+
+  SharedStorage.onChange((payload) => {
+    if (!payload || ['logs', 'targets', 'settings'].includes(payload.target)) {
+      render();
+    }
+  });
+}
+
+function resolveTimezone() {
+  const settings = SharedStorage.getSettings();
+  return settings?.tz || 'Europe/Amsterdam';
+}
+
+function resolveRange(key, tz) {
+  const config = RANGE_CONFIG[key] || RANGE_CONFIG.today;
+  const now = new Date();
+  const end = endOfDayInTz(now, tz);
+  const startReference = addDaysInTz(end, tz, -(config.days - 1));
+  const start = startOfDayInTz(startReference, tz);
+  return { ...config, start, end };
+}
+
+function resolvePreviousRange(range, tz) {
+  if (!range) return null;
+  const previousEndReference = addDaysInTz(range.start, tz, -1);
+  const previousEnd = endOfDayInTz(previousEndReference, tz);
+  const previousStartReference = addDaysInTz(range.start, tz, -range.days);
+  const previousStart = startOfDayInTz(previousStartReference, tz);
+  return {
+    start: previousStart,
+    end: previousEnd,
+    days: range.days,
+    label: range.previousLabel,
+  };
+}
+
+function addDaysInTz(date, tz, amount) {
+  const parts = zonedParts(date, tz);
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day + amount, parts.hour, parts.minute, parts.second));
+}
+
+function startOfDayInTz(date, tz) {
+  const parts = zonedParts(date, tz);
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 0, 0, 0, 0));
+}
+
+function endOfDayInTz(date, tz) {
+  const parts = zonedParts(date, tz);
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 23, 59, 59, 999));
+}
+
+function zonedParts(date, tz) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(date);
+  const result = {
+    year: 1970,
+    month: 1,
+    day: 1,
+    hour: 0,
+    minute: 0,
+    second: 0,
+  };
+  parts.forEach((part) => {
+    if (part.type === 'literal') return;
+    const value = Number(part.value);
+    if (Number.isFinite(value)) {
+      result[part.type] = value;
+    }
+  });
+  return result;
+}
+
+function formatTimezoneLabel(tz) {
+  if (!tz) return 'UTC';
+  return tz.replace(/_/g, ' ');
+}
+
+function hydrationTotalLabel(total, days) {
+  if (!total) {
+    return days > 1 ? `0 ml across ${days} days` : '0 ml logged';
+  }
+  if (total >= 1000) {
+    const liters = Math.round((total / 1000) * 10) / 10;
+    return days > 1 ? `${liters.toFixed(1)} L across ${days} days` : `${liters.toFixed(1)} L logged`;
+  }
+  return days > 1
+    ? `${formatNumber(Math.round(total))} ml across ${days} days`
+    : `${formatNumber(Math.round(total))} ml logged`;
+}
+
+function sleepTotalLabel(total, days) {
+  const label = minutesToHours(total);
+  return days > 1 ? `${label} total across ${days} days` : `${label} logged`;
+}
+
+function stepsTotalLabel(total, days) {
+  const value = formatNumber(Math.round(total));
+  return days > 1 ? `${value} steps across ${days} days` : `${value} steps logged`;
+}
+
+function caffeineTotalLabel(total, days) {
+  const value = formatNumber(Math.round(total));
+  return days > 1 ? `${value} mg across ${days} days` : `${value} mg consumed`;
+}

--- a/assets/js/kpi.js
+++ b/assets/js/kpi.js
@@ -50,7 +50,7 @@ export function initKpi() {
     const targets = SharedStorage.getTargets();
     const today = SharedStorage.aggregateDay(new Date());
     const medsTarget = Array.isArray(targets.meds) ? targets.meds.length : 0;
-    const medsTaken = SharedStorage.listLogs({ type: 'meds', since: startOfDayISO(new Date()) }).length;
+    const medsTaken = SharedStorage.listLogs({ type: 'meds', since: SharedStorage.startOfDayISO(new Date()) }).length;
     const context = { targetCount: medsTarget, medsTaken, missed: medsTarget > medsTaken };
 
     grid.innerHTML = '';
@@ -128,8 +128,3 @@ function getTargetValue(id, targets, context) {
   }
 }
 
-function startOfDayISO(date) {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  return d.toISOString();
-}

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -21,7 +21,7 @@ export function initSidebar() {
 
     medsList.innerHTML = '';
     const meds = Array.isArray(targets.meds) ? targets.meds : [];
-    const takenLogs = SharedStorage.listLogs({ type: 'meds', since: startOfDayISO(new Date()) });
+    const takenLogs = SharedStorage.listLogs({ type: 'meds', since: SharedStorage.startOfDayISO(new Date()) });
 
     meds.forEach((med) => {
       const item = document.createElement('div');
@@ -83,7 +83,7 @@ function toggleMed(med, checked) {
   if (checked) {
     SharedStorage.pushLog('meds', 1, { note: med.name });
   } else {
-    const todays = SharedStorage.listLogs({ type: 'meds', since: startOfDayISO(new Date()) });
+    const todays = SharedStorage.listLogs({ type: 'meds', since: SharedStorage.startOfDayISO(new Date()) });
     const targetLog = todays.find((log) => log.note === med.name);
     if (targetLog) {
       SharedStorage.removeLog(targetLog.id);
@@ -105,11 +105,6 @@ function removeMed(id) {
   SharedStorage.setTargets({ ...targets, meds });
 }
 
-function startOfDayISO(date) {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  return d.toISOString();
-}
 
 function debounce(fn, delay) {
   let timer;

--- a/assets/js/summary-header.js
+++ b/assets/js/summary-header.js
@@ -7,7 +7,53 @@ export function initHeader() {
   const container = document.getElementById(HEADER_ID);
   if (!container) return;
 
+  function ensureStructure() {
+    if (container.dataset.ready) return;
+    container.innerHTML = `
+      <div class="summary-header__inner">
+        <div class="summary-header__row">
+          <div class="summary-header__meta">
+            <span class="snapshot-pill">
+              Wellness snapshot —
+              <strong data-date>—</strong><span data-city></span>
+            </span>
+            <span class="snapshot-pill">Battery <strong data-battery>—%</strong></span>
+          </div>
+          <div class="summary-header__status">
+            <div class="device-status" data-device-status data-state="green">
+              <span aria-hidden="true" data-device-icon>🟢</span>
+              <span data-device-label>Device status · Fresh</span>
+            </div>
+          </div>
+        </div>
+        <section class="hero-kpi" id="hero-kpi" aria-labelledby="hero-kpi-title">
+          <header class="hero-kpi__header">
+            <div>
+              <h1 id="hero-kpi-title">Wellness pace</h1>
+              <p class="hero-kpi__subtitle" id="hero-kpi-caption">Range —</p>
+            </div>
+            <div class="hero-kpi__filters" role="group" aria-label="Range selector">
+              <button type="button" class="hero-kpi__filter is-active" data-range="today" aria-pressed="true">Today</button>
+              <button type="button" class="hero-kpi__filter" data-range="7d" aria-pressed="false">7&nbsp;days</button>
+              <button type="button" class="hero-kpi__filter" data-range="30d" aria-pressed="false">30&nbsp;days</button>
+            </div>
+          </header>
+          <div class="hero-kpi__body">
+            <div class="hero-kpi__score">
+              <span class="hero-kpi__label">Goal completion</span>
+              <span class="hero-kpi__value" id="hero-kpi-score">0%</span>
+              <span class="hero-kpi__delta" id="hero-kpi-delta" data-trend="flat">Awaiting data</span>
+            </div>
+            <ul class="hero-kpi__list" id="hero-kpi-list"></ul>
+          </div>
+        </section>
+      </div>
+    `;
+    container.dataset.ready = 'true';
+  }
+
   function render() {
+    ensureStructure();
     const settings = SharedStorage.getSettings();
     const now = new Date();
     const dateLabel = formatDateRange(now);
@@ -15,20 +61,20 @@ export function initHeader() {
     const battery = settings.deviceBattery ?? 0;
     const lastPing = settings.lastDevicePing ? new Date(settings.lastDevicePing) : null;
     const status = computeDeviceStatus(lastPing);
-    container.innerHTML = `
-      <div class="summary-header__inner">
-        <div class="summary-header__meta">
-          <span class="snapshot-pill">Wellness snapshot — <strong>${dateLabel}</strong>${city}</span>
-          <span class="snapshot-pill">Battery <strong>${battery}%</strong></span>
-        </div>
-        <div class="summary-header__status">
-          <div class="device-status" data-state="${status.color}">
-            <span aria-hidden="true">${status.icon}</span>
-            <span>${status.label}</span>
-          </div>
-        </div>
-      </div>
-    `;
+
+    const dateEl = container.querySelector('[data-date]');
+    const cityEl = container.querySelector('[data-city]');
+    const batteryEl = container.querySelector('[data-battery]');
+    const statusEl = container.querySelector('[data-device-status]');
+    const statusIconEl = container.querySelector('[data-device-icon]');
+    const statusLabelEl = container.querySelector('[data-device-label]');
+
+    if (dateEl) dateEl.textContent = dateLabel;
+    if (cityEl) cityEl.textContent = city;
+    if (batteryEl) batteryEl.textContent = `${battery}%`;
+    if (statusEl) statusEl.dataset.state = status.color;
+    if (statusIconEl) statusIconEl.textContent = status.icon;
+    if (statusLabelEl) statusLabelEl.textContent = status.label;
   }
 
   render();

--- a/assets/js/summary-page.js
+++ b/assets/js/summary-page.js
@@ -1,5 +1,6 @@
 import { initHeader } from './summary-header.js';
 import { initKpi } from './kpi.js';
+import { initHeroKpi } from './hero-kpi.js';
 import { initQuickActions } from './quick-actions.js';
 import { initTimeline } from './timeline.js';
 import { initInsights } from './insights.js';
@@ -18,6 +19,7 @@ function ready(callback) {
 
 ready(() => {
   initHeader();
+  initHeroKpi();
   initKpi();
   initQuickActions();
   initTimeline();

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -9,7 +9,7 @@ export function initTimeline() {
   if (!list) return;
 
   function render() {
-    const logs = SharedStorage.listLogs({ since: startOfDayISO(new Date()) });
+    const logs = SharedStorage.listLogs({ since: SharedStorage.startOfDayISO(new Date()) });
     list.innerHTML = '';
     if (headerCount) {
       headerCount.textContent = `${logs.length} events`;
@@ -172,8 +172,3 @@ function formatValue(log) {
   return `${log.value} ${unit}`;
 }
 
-function startOfDayISO(date) {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  return d.toISOString();
-}


### PR DESCRIPTION
## Summary
- add a hero KPI section to the summary header with interactive range filters and styling
- implement hero KPI logic that aggregates metrics across selectable ranges with timezone awareness
- update shared storage day calculations and related modules to use the timezone-aware start-of-day helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6bb84541c83328f24caebe6594b02