### PR TITLE
Add base-aware module bootstrap for Summary page

### DIFF
--- a/Summary.html
+++ b/Summary.html
@@ -83,7 +83,7 @@
     <div class="summary-viewport">
       <header id="summary-header" class="summary-header" role="banner"></header>
       <main class="summary-main" id="main" role="main">
-        <section aria-labelledby="kpi-heading" class="kpi-grid" id="kpi-grid" role="region">
+        <section aria-labelledby="kpi-heading" class="kpi-grid" id="kpi-grid" role="region" data-kpi-rings>
           <h2 id="kpi-heading" class="visually-hidden">Key wellness metrics</h2>
         </section>
         <section class="quick-actions" aria-labelledby="actions-heading" role="region">

--- a/assets/css/summary.css
+++ b/assets/css/summary.css
@@ -390,6 +390,19 @@
   padding: 1.5rem;
 }
 
+.kpi-rings__status {
+  grid-column: 1 / -1;
+  padding: 1rem 1.25rem;
+  border-radius: calc(var(--radius) - 8px);
+  background: rgba(2, 6, 23, 0.45);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+}
+
+.kpi-rings__status p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
 .kpi-card {
   display: grid;
   gap: 1.25rem;

--- a/assets/js/kpi-rings.js
+++ b/assets/js/kpi-rings.js
@@ -1,0 +1,74 @@
+import { SharedStorage } from './sharedStorage.js';
+
+const SECTION_ID = 'kpi-grid';
+const LABEL_SELECTOR = '[data-kpi-rings-label]';
+
+function resolveContainer() {
+  return document.querySelector('[data-kpi-rings]') || document.getElementById(SECTION_ID);
+}
+
+function ensureStructure(container) {
+  if (!container) return null;
+
+  let wrapper = container.querySelector('[data-kpi-rings-wrapper]');
+  if (!wrapper) {
+    wrapper = document.createElement('div');
+    wrapper.className = 'kpi-rings__status';
+    wrapper.dataset.kpiRingsWrapper = 'true';
+    wrapper.innerHTML = `<p class="muted" data-kpi-rings-label>Monitoring daily completion…</p>`;
+    container.appendChild(wrapper);
+  } else if (!wrapper.querySelector(LABEL_SELECTOR)) {
+    wrapper.innerHTML = `<p class="muted" data-kpi-rings-label>Monitoring daily completion…</p>`;
+  }
+
+  return container.querySelector(LABEL_SELECTOR);
+}
+
+function computeSnapshot() {
+  const targets = SharedStorage.getTargets();
+  const today = SharedStorage.aggregateDay(new Date());
+  return {
+    water: calculateProgress(today.water, targets.water),
+    sleep: calculateProgress(today.sleep, targets.sleep),
+    steps: calculateProgress(today.steps, targets.steps),
+    caffeine: calculateProgressReverse(today.caffeine, targets.caffeine),
+  };
+}
+
+function calculateProgress(value, target) {
+  if (!target) return 0;
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return Math.max(0, Math.min(100, Math.round((safeValue / target) * 100)));
+}
+
+function calculateProgressReverse(value, target) {
+  if (!target) return 0;
+  const safeValue = Number.isFinite(value) ? value : 0;
+  const percent = Math.max(0, Math.min(100, Math.round((safeValue / target) * 100)));
+  return Math.max(0, 100 - percent);
+}
+
+function render(container) {
+  const label = ensureStructure(container);
+  if (!label) return;
+
+  const snapshot = computeSnapshot();
+  const segments = [
+    `Water ${snapshot.water}%`,
+    `Sleep ${snapshot.sleep}%`,
+    `Steps ${snapshot.steps}%`,
+    `Caffeine ${snapshot.caffeine}% budget`,
+  ];
+  label.textContent = segments.join(' · ');
+}
+
+export function initKpiRings() {
+  const container = resolveContainer();
+  if (!container) return;
+
+  render(container);
+  SharedStorage.onChange(() => render(container));
+}
+
+export default initKpiRings;
+

--- a/assets/js/path.js
+++ b/assets/js/path.js
@@ -1,0 +1,84 @@
+const ABSOLUTE_URL_PATTERN = /^(?:[a-z]+:)?\/\//i;
+
+function ensureTrailingSlash(value) {
+  if (!value) return '/';
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function computeBaseURL() {
+  if (typeof window === 'undefined') {
+    return new URL('./', 'http://localhost');
+  }
+
+  const globalBase = typeof window.__HEALTH2099_BASE__ === 'string' ? window.__HEALTH2099_BASE__ : null;
+  const documentBase =
+    (typeof document !== 'undefined' && document.querySelector('base')?.getAttribute('href')) || null;
+  const datasetBase =
+    typeof document !== 'undefined' && document.documentElement?.dataset?.base
+      ? document.documentElement.dataset.base
+      : null;
+  const metaBase =
+    typeof document !== 'undefined'
+      ? document.querySelector('meta[name="health-base"]')?.getAttribute('content')
+      : null;
+
+  const candidate = globalBase || datasetBase || metaBase || documentBase;
+
+  if (candidate) {
+    try {
+      return new URL(ensureTrailingSlash(candidate), window.location.href);
+    } catch (error) {
+      console.warn('[path] Failed to resolve base candidate', error);
+    }
+  }
+
+  try {
+    return new URL('./', window.location.href);
+  } catch (error) {
+    console.warn('[path] Falling back to origin for base resolution', error);
+    return new URL('./', `${window.location.origin || 'http://localhost'}/`);
+  }
+}
+
+const baseURL = computeBaseURL();
+
+function normalizeResult(url) {
+  if (!url) return '';
+  if (ABSOLUTE_URL_PATTERN.test(url)) {
+    return url;
+  }
+  try {
+    const resolved = new URL(url, baseURL);
+    return `${resolved.pathname}${resolved.search}${resolved.hash}` || '/';
+  } catch (error) {
+    console.warn('[path] Failed to normalize url', url, error);
+    return url;
+  }
+}
+
+export function withBase(path = '') {
+  if (typeof path !== 'string' || path.trim() === '') {
+    return `${baseURL.pathname}`;
+  }
+
+  if (ABSOLUTE_URL_PATTERN.test(path)) {
+    return path;
+  }
+
+  if (path.startsWith('/')) {
+    return normalizeResult(path);
+  }
+
+  const cleaned = path.replace(/^\.\//, '');
+  return normalizeResult(`${baseURL.pathname}${cleaned}`);
+}
+
+export function resolveModulePaths(paths) {
+  if (!Array.isArray(paths)) return [];
+  return paths.map((item) => withBase(item));
+}
+
+export function getBasePath() {
+  return `${baseURL.pathname}`;
+}
+

--- a/assets/js/summary-page.js
+++ b/assets/js/summary-page.js
@@ -1,13 +1,4 @@
-import { initHeader } from './summary-header.js';
-import { initKpi } from './kpi.js';
-import { initHeroKpi } from './hero-kpi.js';
-import { initQuickActions } from './quick-actions.js';
-import { initTimeline } from './timeline.js';
-import { initInsights } from './insights.js';
-import { initStreaks } from './streaks.js';
-import { initSidebar } from './sidebar.js';
-import { initDevSeed } from './dev-seed.js';
-import './ui.js';
+import { withBase } from './path.js';
 
 function ready(callback) {
   if (document.readyState === 'complete' || document.readyState === 'interactive') {
@@ -17,14 +8,54 @@ function ready(callback) {
   }
 }
 
-ready(() => {
-  initHeader();
-  initHeroKpi();
-  initKpi();
-  initQuickActions();
-  initTimeline();
-  initInsights();
-  initStreaks();
-  initSidebar();
-  initDevSeed();
+function loadModule(path) {
+  return import(withBase(path)).catch((error) => {
+    console.error(`Failed to load module ${path}`, error);
+    return null;
+  });
+}
+
+ready(async () => {
+  const [
+    sharedStorage,
+    headerModule,
+    heroModule,
+    kpiModule,
+    quickActionsModule,
+    timelineModule,
+    insightsModule,
+    streaksModule,
+    sidebarModule,
+    devSeedModule,
+    kpiRingsModule,
+  ] = await Promise.all([
+    loadModule('assets/js/sharedStorage.js'),
+    loadModule('assets/js/summary-header.js'),
+    loadModule('assets/js/hero-kpi.js'),
+    loadModule('assets/js/kpi.js'),
+    loadModule('assets/js/quick-actions.js'),
+    loadModule('assets/js/timeline.js'),
+    loadModule('assets/js/insights.js'),
+    loadModule('assets/js/streaks.js'),
+    loadModule('assets/js/sidebar.js'),
+    loadModule('assets/js/dev-seed.js'),
+    loadModule('assets/js/kpi-rings.js'),
+  ]);
+
+  if (!sharedStorage || !sharedStorage.SharedStorage) {
+    console.error('Shared storage module failed to load; page modules may not work correctly.');
+    return;
+  }
+
+  headerModule?.initHeader?.();
+  heroModule?.initHeroKpi?.();
+  kpiModule?.initKpi?.();
+  quickActionsModule?.initQuickActions?.();
+  timelineModule?.initTimeline?.();
+  insightsModule?.initInsights?.();
+  streaksModule?.initStreaks?.();
+  sidebarModule?.initSidebar?.();
+  devSeedModule?.initDevSeed?.();
+  kpiRingsModule?.initKpiRings?.();
 });
+


### PR DESCRIPTION
## Summary
- add a reusable `withBase` helper to resolve asset URLs relative to the deployed base path
- update the summary bootstrap to dynamically import feature modules with the helper and add a KPI rings renderer
- expose a hook and styles for the KPI rings status so the section no longer renders empty

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6c07169508332a3f8182e32a71f1a