### PR TITLE
Add live glass KPI rings to summary dashboard

### DIFF
--- a/Summary.html
+++ b/Summary.html
@@ -8,6 +8,7 @@
     <link rel="preload" href="assets/css/summary.css?v=20240714" as="style" />
     <link rel="preload" href="assets/css/animations.css?v=20240714" as="style" />
     <link rel="preload" href="assets/css/timeline.css?v=20240714" as="style" />
+    <link rel="preload" href="assets/css/kpi-rings.css?v=20240714" as="style" />
     <style>
       :root {
         color-scheme: dark;
@@ -69,6 +70,7 @@
     <link rel="stylesheet" href="assets/css/summary.css?v=20240714" media="print" onload="this.media='all'" />
     <link rel="stylesheet" href="assets/css/animations.css?v=20240714" media="print" onload="this.media='all'" />
     <link rel="stylesheet" href="assets/css/timeline.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" href="assets/css/kpi-rings.css?v=20240714" media="print" onload="this.media='all'" />
     <link rel="stylesheet" href="assets/css/badges.css?v=20240714" media="print" onload="this.media='all'" />
     <noscript>
       <link rel="stylesheet" href="assets/css/theme.css?v=20240714" />
@@ -76,6 +78,7 @@
       <link rel="stylesheet" href="assets/css/animations.css?v=20240714" />
       <link rel="stylesheet" href="assets/css/timeline.css?v=20240714" />
       <link rel="stylesheet" href="assets/css/badges.css?v=20240714" />
+      <link rel="stylesheet" href="assets/css/kpi-rings.css?v=20240714" />
     </noscript>
   </head>
   <body class="app-shell" data-page="summary">

--- a/assets/css/kpi-rings.css
+++ b/assets/css/kpi-rings.css
@@ -1,0 +1,146 @@
+.kpi-rings {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  padding: 0.5rem 0 0.25rem;
+}
+
+.kpi-ring {
+  --ring-track: rgba(15, 23, 42, 0.55);
+  --ring-inner: rgba(15, 23, 42, 0.65);
+  --ring-border: rgba(148, 163, 184, 0.3);
+  --ring-accent: #38bdf8;
+  --ring-glow: rgba(56, 189, 248, 0.35);
+  display: grid;
+  gap: 0.85rem;
+  justify-items: center;
+}
+
+.kpi-ring[data-tone='warning'] {
+  --ring-accent: #facc15;
+  --ring-glow: rgba(250, 204, 21, 0.3);
+}
+
+.kpi-ring[data-tone='danger'] {
+  --ring-accent: #f87171;
+  --ring-glow: rgba(248, 113, 113, 0.32);
+}
+
+.kpi-ring[data-tone='neutral'] {
+  --ring-accent: rgba(148, 163, 184, 0.45);
+  --ring-glow: rgba(148, 163, 184, 0.24);
+}
+
+.kpi-ring[data-complete='true'] .kpi-ring__progress {
+  box-shadow: 0 0 0 1px var(--ring-border), 0 0 22px var(--ring-glow), 0 28px 48px rgba(2, 6, 23, 0.55);
+}
+
+.kpi-ring__circle {
+  width: min(180px, 100%);
+  aspect-ratio: 1 / 1;
+  position: relative;
+  filter: drop-shadow(0 20px 36px rgba(2, 6, 23, 0.45));
+}
+
+.kpi-ring__progress {
+  position: absolute;
+  inset: 0;
+  padding: 9px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--ring-accent) calc(var(--fill, 0) * 1deg),
+    var(--ring-track) calc(var(--fill, 0) * 1deg)
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 320ms ease, box-shadow 320ms ease;
+  box-shadow: 0 0 0 1px var(--ring-border), 0 24px 42px rgba(2, 6, 23, 0.48);
+}
+
+.kpi-ring[data-over='true'] .kpi-ring__progress {
+  background: conic-gradient(
+    var(--ring-accent) calc(var(--fill, 0) * 1deg),
+    rgba(248, 113, 113, 0.35) calc(var(--fill, 0) * 1deg)
+  );
+}
+
+.kpi-ring__inner {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: linear-gradient(140deg, rgba(30, 64, 175, 0.2), rgba(12, 74, 110, 0.1));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  padding: 1.25rem 1rem;
+  text-align: center;
+  gap: 0.35rem;
+}
+
+.kpi-ring__percent {
+  font-size: clamp(1.35rem, 1.8vw, 1.85rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.kpi-ring__measure {
+  font-size: 0.95rem;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.kpi-ring__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.kpi-ring__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.kpi-ring__status[data-tone='on-track'] {
+  border-color: rgba(56, 189, 248, 0.35);
+  color: #38bdf8;
+}
+
+.kpi-ring__status[data-tone='warning'] {
+  border-color: rgba(250, 204, 21, 0.32);
+  color: #facc15;
+}
+
+.kpi-ring__status[data-tone='danger'] {
+  border-color: rgba(248, 113, 113, 0.38);
+  color: #f87171;
+}
+
+.kpi-ring__status[data-tone='neutral'] {
+  border-color: rgba(148, 163, 184, 0.26);
+  color: rgba(226, 232, 240, 0.7);
+}
+
+@media (max-width: 640px) {
+  .kpi-ring__percent {
+    font-size: 1.2rem;
+  }
+
+  .kpi-ring__measure {
+    font-size: 0.85rem;
+  }
+}

--- a/assets/js/kpi-rings.js
+++ b/assets/js/kpi-rings.js
@@ -1,65 +1,207 @@
 import { SharedStorage } from './sharedStorage.js';
+import { formatNumber, minutesToHours } from './utils.js';
 
 const SECTION_ID = 'kpi-grid';
-const LABEL_SELECTOR = '[data-kpi-rings-label]';
+
+const METRICS = [
+  { id: 'hydration', label: 'Hydration', type: 'water', unit: 'ml' },
+  { id: 'sleep', label: 'Sleep', type: 'sleep', unit: 'min' },
+  { id: 'steps', label: 'Steps', type: 'steps', unit: 'steps' },
+  { id: 'caffeine', label: 'Caffeine', type: 'caffeine', unit: 'mg' },
+  { id: 'meds', label: 'Meds', type: 'meds', unit: 'dose' },
+];
 
 function resolveContainer() {
   return document.querySelector('[data-kpi-rings]') || document.getElementById(SECTION_ID);
 }
 
-function ensureStructure(container) {
+function ensureHost(container) {
   if (!container) return null;
-
-  let wrapper = container.querySelector('[data-kpi-rings-wrapper]');
-  if (!wrapper) {
-    wrapper = document.createElement('div');
-    wrapper.className = 'kpi-rings__status';
-    wrapper.dataset.kpiRingsWrapper = 'true';
-    wrapper.innerHTML = `<p class="muted" data-kpi-rings-label>Monitoring daily completion…</p>`;
-    container.appendChild(wrapper);
-  } else if (!wrapper.querySelector(LABEL_SELECTOR)) {
-    wrapper.innerHTML = `<p class="muted" data-kpi-rings-label>Monitoring daily completion…</p>`;
+  let host = container.querySelector('[data-kpi-rings-host]');
+  if (!host) {
+    host = document.createElement('div');
+    host.className = 'kpi-rings';
+    host.dataset.kpiRingsHost = 'true';
+    host.setAttribute('role', 'list');
+    host.setAttribute('aria-label', 'Daily wellness progress rings');
+    container.insertBefore(host, container.firstChild);
   }
-
-  return container.querySelector(LABEL_SELECTOR);
+  return host;
 }
 
-function computeSnapshot() {
+function computeMetrics() {
+  const now = new Date();
   const targets = SharedStorage.getTargets();
-  const today = SharedStorage.aggregateDay(new Date());
-  return {
-    water: calculateProgress(today.water, targets.water),
-    sleep: calculateProgress(today.sleep, targets.sleep),
-    steps: calculateProgress(today.steps, targets.steps),
-    caffeine: calculateProgressReverse(today.caffeine, targets.caffeine),
-  };
+  const today = SharedStorage.aggregateDay(now);
+  const medsScheduled = Array.isArray(targets.meds) ? targets.meds.length : 0;
+  const medsTaken = SharedStorage.listLogs({
+    type: 'meds',
+    since: SharedStorage.startOfDayISO(now),
+  }).length;
+
+  return METRICS.map((metric) => {
+    const targetValue = getTargetValue(metric, targets, medsScheduled);
+    const actualValue = metric.id === 'meds' ? medsTaken : today[metric.type] || 0;
+    const percent = computePercent(metric.id, actualValue, targetValue, medsScheduled);
+    const cappedDegrees = toDegrees(metric.id, percent);
+    const status = resolveStatus(metric.id, actualValue, targetValue, percent, {
+      medsScheduled,
+      medsTaken,
+    });
+    return {
+      ...metric,
+      actualValue,
+      targetValue,
+      percent,
+      cappedDegrees,
+      status,
+      display: formatDisplay(metric.id, actualValue, targetValue, {
+        medsScheduled,
+        medsTaken,
+      }),
+      overTarget: metric.id === 'caffeine' && targetValue > 0 ? actualValue > targetValue : false,
+      complete: metric.id === 'meds'
+        ? medsScheduled > 0 && medsTaken >= medsScheduled
+        : percent >= 100 && targetValue > 0,
+    };
+  });
 }
 
-function calculateProgress(value, target) {
-  if (!target) return 0;
-  const safeValue = Number.isFinite(value) ? value : 0;
-  return Math.max(0, Math.min(100, Math.round((safeValue / target) * 100)));
+function getTargetValue(metric, targets, medsScheduled) {
+  switch (metric.id) {
+    case 'hydration':
+      return targets.water || 0;
+    case 'sleep':
+      return targets.sleep || 0;
+    case 'steps':
+      return targets.steps || 0;
+    case 'caffeine':
+      return targets.caffeine || 0;
+    case 'meds':
+      return medsScheduled;
+    default:
+      return 0;
+  }
 }
 
-function calculateProgressReverse(value, target) {
+function computePercent(id, actual, target, medsScheduled) {
+  if (id === 'meds') {
+    if (!medsScheduled) return 100;
+    return Math.round(Math.min((actual / medsScheduled) * 100, 150));
+  }
   if (!target) return 0;
-  const safeValue = Number.isFinite(value) ? value : 0;
-  const percent = Math.max(0, Math.min(100, Math.round((safeValue / target) * 100)));
-  return Math.max(0, 100 - percent);
+  const ratio = actual / target;
+  return Math.round(Math.max(0, ratio * 100));
+}
+
+function toDegrees(id, percent) {
+  const cap = id === 'meds' ? 100 : 130;
+  const normalized = Math.min(Math.max(percent, 0), cap);
+  const limited = Math.min(normalized, 100);
+  return (limited / 100) * 360;
+}
+
+function resolveStatus(id, actual, target, percent, context) {
+  switch (id) {
+    case 'hydration':
+    case 'sleep':
+    case 'steps': {
+      if (!target) return { tone: 'neutral', label: 'Set goal' };
+      if (percent >= 100) return { tone: 'on-track', label: 'On track' };
+      if (percent >= 60) return { tone: 'warning', label: 'Warning' };
+      return { tone: 'danger', label: 'Missed' };
+    }
+    case 'caffeine': {
+      if (!target) return { tone: 'neutral', label: 'Set goal' };
+      const ratio = target ? actual / target : 0;
+      if (ratio <= 0.8) return { tone: 'on-track', label: 'On track' };
+      if (ratio <= 1) return { tone: 'warning', label: 'Warning' };
+      return { tone: 'danger', label: 'Danger' };
+    }
+    case 'meds': {
+      if (!context.medsScheduled) return { tone: 'neutral', label: 'No meds' };
+      if (context.medsTaken >= context.medsScheduled) return { tone: 'on-track', label: 'On track' };
+      return { tone: 'danger', label: 'Danger' };
+    }
+    default:
+      return { tone: 'neutral', label: 'Set goal' };
+  }
+}
+
+function formatDisplay(id, actual, target, context) {
+  switch (id) {
+    case 'hydration':
+      return target ? `${formatNumber(actual)} / ${formatNumber(target)} ml` : `${formatNumber(actual)} ml`;
+    case 'sleep': {
+      const formattedActual = minutesToHours(actual);
+      return target ? `${formattedActual} / ${minutesToHours(target)}` : formattedActual;
+    }
+    case 'steps':
+      return target ? `${formatNumber(actual)} / ${formatNumber(target)} steps` : `${formatNumber(actual)} steps`;
+    case 'caffeine':
+      return target ? `${formatNumber(actual)} / ${formatNumber(target)} mg` : `${formatNumber(actual)} mg`;
+    case 'meds': {
+      const scheduled = context.medsScheduled || 0;
+      if (!scheduled) return `${context.medsTaken || 0} / 0`;
+      return `${context.medsTaken || 0} / ${scheduled}`;
+    }
+    default:
+      return `${formatNumber(actual)}`;
+  }
 }
 
 function render(container) {
-  const label = ensureStructure(container);
-  if (!label) return;
+  const host = ensureHost(container);
+  if (!host) return;
 
-  const snapshot = computeSnapshot();
-  const segments = [
-    `Water ${snapshot.water}%`,
-    `Sleep ${snapshot.sleep}%`,
-    `Steps ${snapshot.steps}%`,
-    `Caffeine ${snapshot.caffeine}% budget`,
-  ];
-  label.textContent = segments.join(' · ');
+  const metrics = computeMetrics();
+  host.innerHTML = '';
+
+  metrics.forEach((metric) => {
+    const item = document.createElement('article');
+    item.className = 'kpi-ring';
+    item.dataset.tone = metric.status.tone;
+    if (metric.complete) item.dataset.complete = 'true';
+    if (metric.overTarget) item.dataset.over = 'true';
+    item.setAttribute('role', 'listitem');
+    item.setAttribute('aria-label', `${metric.label} ${metric.percent}%`);
+
+    const circle = document.createElement('div');
+    circle.className = 'kpi-ring__circle';
+
+    const progress = document.createElement('div');
+    progress.className = 'kpi-ring__progress';
+    progress.style.setProperty('--fill', `${metric.cappedDegrees}`);
+
+    const inner = document.createElement('div');
+    inner.className = 'kpi-ring__inner';
+
+    const percent = document.createElement('span');
+    percent.className = 'kpi-ring__percent';
+    const displayPercent = Number.isFinite(metric.percent) ? Math.max(0, metric.percent) : 0;
+    percent.textContent = `${Math.min(999, Math.round(displayPercent))}%`;
+
+    const measure = document.createElement('span');
+    measure.className = 'kpi-ring__measure';
+    measure.textContent = metric.display;
+
+    const label = document.createElement('span');
+    label.className = 'kpi-ring__label';
+    label.textContent = metric.label;
+
+    inner.append(percent, measure, label);
+    progress.appendChild(inner);
+    circle.appendChild(progress);
+    item.appendChild(circle);
+
+    const status = document.createElement('span');
+    status.className = 'kpi-ring__status';
+    status.dataset.tone = metric.status.tone;
+    status.textContent = metric.status.label;
+
+    item.appendChild(status);
+    host.appendChild(item);
+  });
 }
 
 export function initKpiRings() {


### PR DESCRIPTION
## Summary
- load the new KPI ring styles on the summary page
- render hydration, sleep, steps, caffeine, and meds glass progress rings with live status logic
- highlight status colours according to goal progress and BroadcastChannel updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6c394dc7883329d65446277f0a342