### PR TITLE
Align summary dashboard data model with base-aware asset loading

### DIFF
--- a/Summary.html
+++ b/Summary.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#2563eb" />
-    <link rel="manifest" href="./manifest.webmanifest" />
-    <link rel="preload" href="assets/css/summary.css?v=20240714" as="style" />
-    <link rel="preload" href="assets/css/animations.css?v=20240714" as="style" />
-    <link rel="preload" href="assets/css/timeline.css?v=20240714" as="style" />
-    <link rel="preload" href="assets/css/kpi-rings.css?v=20240714" as="style" />
-    <link rel="preload" href="assets/css/ui.css?v=20240714" as="style" />
+    <link rel="manifest" data-asset="href" data-href="manifest.webmanifest" />
+    <link rel="preload" data-asset="href" data-href="assets/css/summary.css?v=20240714" as="style" />
+    <link rel="preload" data-asset="href" data-href="assets/css/animations.css?v=20240714" as="style" />
+    <link rel="preload" data-asset="href" data-href="assets/css/timeline.css?v=20240714" as="style" />
+    <link rel="preload" data-asset="href" data-href="assets/css/kpi-rings.css?v=20240714" as="style" />
+    <link rel="preload" data-asset="href" data-href="assets/css/ui.css?v=20240714" as="style" />
     <style>
       :root {
         color-scheme: dark;
@@ -67,13 +67,58 @@
         }
       }
     </style>
-    <link rel="stylesheet" href="assets/css/theme.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" href="assets/css/summary.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" href="assets/css/animations.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" href="assets/css/timeline.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" href="assets/css/kpi-rings.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" href="assets/css/ui.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" href="assets/css/badges.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" data-asset="href" data-href="assets/css/theme.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" data-asset="href" data-href="assets/css/summary.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" data-asset="href" data-href="assets/css/animations.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" data-asset="href" data-href="assets/css/timeline.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" data-asset="href" data-href="assets/css/kpi-rings.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" data-asset="href" data-href="assets/css/ui.css?v=20240714" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" data-asset="href" data-href="assets/css/badges.css?v=20240714" media="print" onload="this.media='all'" />
+    <script>
+      (function () {
+        const ABSOLUTE = /^(?:[a-z]+:)?\/\//i;
+        function ensureTrailingSlash(value) {
+          if (!value) return '/';
+          return value.endsWith('/') ? value : `${value}/`;
+        }
+        function computeBase() {
+          const fromGlobal = typeof window.__HEALTH2099_BASE__ === 'string' ? window.__HEALTH2099_BASE__ : null;
+          if (fromGlobal) return ensureTrailingSlash(fromGlobal);
+          const { pathname } = window.location;
+          const base = pathname.endsWith('/') ? pathname : pathname.replace(/[^/]*$/, '');
+          return ensureTrailingSlash(base);
+        }
+        const basePath = computeBase();
+        function withBase(path) {
+          if (!path || ABSOLUTE.test(path)) return path;
+          if (path.startsWith('/')) return path;
+          return `${basePath}${path.replace(/^\.\//, '')}`;
+        }
+        window.__HEALTH2099_BASE__ = basePath;
+        window.__HEALTH2099_WITH_BASE__ = withBase;
+        function applyAssets() {
+          const nodes = document.querySelectorAll('[data-asset]');
+          nodes.forEach((node) => {
+            const attr = node.getAttribute('data-asset');
+            const original = node.getAttribute(`data-${attr}`);
+            if (!attr || !original) return;
+            const value = withBase(original);
+            if (attr === 'href') {
+              node.setAttribute('href', value);
+            } else if (attr === 'src') {
+              node.setAttribute('src', value);
+            }
+          });
+        }
+        const observer = new MutationObserver(() => applyAssets());
+        observer.observe(document.documentElement, { childList: true, subtree: true });
+        document.addEventListener('DOMContentLoaded', () => {
+          applyAssets();
+          observer.disconnect();
+        });
+        applyAssets();
+      })();
+    </script>
     <noscript>
       <link rel="stylesheet" href="assets/css/theme.css?v=20240714" />
       <link rel="stylesheet" href="assets/css/summary.css?v=20240714" />
@@ -159,7 +204,7 @@
     <footer class="summary-footer" role="contentinfo">
       Synced via shared storage · Broadcast ready
     </footer>
-    <script src="./shared/nav-loader.js" defer></script>
-    <script type="module" src="assets/js/summary-page.js?v=20240714" defer></script>
+    <script data-asset="src" data-src="shared/nav-loader.js" defer></script>
+    <script type="module" data-asset="src" data-src="assets/js/summary-page.js?v=20240714" defer></script>
   </body>
 </html>

--- a/assets/js/dev-seed.js
+++ b/assets/js/dev-seed.js
@@ -9,8 +9,8 @@ export function initDevSeed() {
     const now = new Date();
     for (let d = 0; d < days; d += 1) {
       const dayDate = new Date(now.getTime() - d * 86400000);
-      ['water', 'steps', 'sleep', 'caffeine', 'meds'].forEach((type) => {
-        const count = type === 'meds' ? 1 : 2;
+      ['water', 'steps', 'sleep', 'caffeine', 'med'].forEach((type) => {
+        const count = type === 'med' ? 1 : 2;
         for (let i = 0; i < count; i += 1) {
           const timestamp = new Date(dayDate);
           timestamp.setHours(8 + i * 4, Math.floor(Math.random() * 60), 0, 0);
@@ -23,9 +23,13 @@ export function initDevSeed() {
     });
     SharedStorage.setSettings({
       city: 'Amsterdam',
-      deviceBattery: 82,
-      lastDevicePing: new Date().toISOString(),
+      batteryPct: 82,
+      lastDevicePingISO: new Date().toISOString(),
     });
+    SharedStorage.setMedsToday([
+      { id: 'med_demo_1', title: 'Morning med', taken: true },
+      { id: 'med_demo_2', title: 'Evening med', taken: false },
+    ]);
   });
 }
 
@@ -39,7 +43,7 @@ function valueForType(type) {
       return 360 + Math.floor(Math.random() * 120);
     case 'caffeine':
       return 80 + Math.floor(Math.random() * 60);
-    case 'meds':
+    case 'med':
       return 1;
     default:
       return 0;
@@ -48,7 +52,7 @@ function valueForType(type) {
 
 function noteForType(type) {
   switch (type) {
-    case 'meds':
+    case 'med':
       return 'Daily med';
     case 'water':
       return 'Hydration';

--- a/assets/js/hero-kpi.js
+++ b/assets/js/hero-kpi.js
@@ -5,10 +5,11 @@ const HERO_ID = 'hero-kpi';
 
 const METRICS = [
   {
-    id: 'water',
+    id: 'hydration',
     label: 'Hydration',
     icon: '💧',
-    targetKey: 'water',
+    totalKey: 'water_ml',
+    targetKey: 'water_ml',
     statusType: 'hydration',
     better: 'high',
     formatAverage: (value) => `${formatNumber(Math.round(value))} ml avg`,
@@ -19,7 +20,8 @@ const METRICS = [
     id: 'sleep',
     label: 'Sleep',
     icon: '🌙',
-    targetKey: 'sleep',
+    totalKey: 'sleep_min',
+    targetKey: 'sleep_min',
     statusType: 'sleep',
     better: 'high',
     formatAverage: (value) => `${minutesToHours(value)} avg`,
@@ -30,6 +32,7 @@ const METRICS = [
     id: 'steps',
     label: 'Steps',
     icon: '👟',
+    totalKey: 'steps',
     targetKey: 'steps',
     statusType: 'steps',
     better: 'high',
@@ -41,7 +44,8 @@ const METRICS = [
     id: 'caffeine',
     label: 'Caffeine',
     icon: '☕',
-    targetKey: 'caffeine',
+    totalKey: 'caffeine_mg',
+    targetKey: 'caffeine_mg',
     statusType: 'caffeine',
     better: 'low',
     formatAverage: (value) => `${formatNumber(Math.round(value))} mg avg`,
@@ -114,7 +118,7 @@ export function initHeroKpi() {
     const targets = SharedStorage.getTargets();
 
     const metricPayloads = METRICS.map((metric) => {
-      const total = totals[metric.id] || 0;
+      const total = totals[metric.totalKey] || 0;
       const dailyTarget = targets[metric.targetKey] || 0;
       const aggregateTarget = dailyTarget * range.days;
       const progressPercent = aggregateTarget ? percent(total, aggregateTarget) : 0;
@@ -149,7 +153,7 @@ export function initHeroKpi() {
     if (previousRange) {
       const previousTotals = SharedStorage.aggregateRange(previousRange.start, previousRange.end);
       const previousCompletions = METRICS.map((metric) => {
-        const total = previousTotals[metric.id] || 0;
+        const total = previousTotals[metric.totalKey] || 0;
         const dailyTarget = targets[metric.targetKey] || 0;
         const aggregateTarget = dailyTarget * previousRange.days;
         const progressPercent = aggregateTarget ? percent(total, aggregateTarget) : 0;

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -1,5 +1,5 @@
 import { SharedStorage } from './sharedStorage.js';
-import { percent, minutesToHours } from './utils.js';
+import { percent, formatNumber } from './utils.js';
 
 export function initInsights() {
   const container = document.getElementById('insights');
@@ -8,7 +8,8 @@ export function initInsights() {
   function render() {
     const items = computeInsights();
     container.innerHTML = '';
-    if (!items.length) {
+    const limited = items.slice(0, 3);
+    if (!limited.length) {
       const empty = document.createElement('div');
       empty.className = 'insight-item';
       empty.innerHTML = `<strong>Everything synced</strong><span>You're meeting today's targets so far.</span>`;
@@ -16,7 +17,7 @@ export function initInsights() {
       return;
     }
 
-    items.slice(0, 3).forEach((insight) => {
+    limited.forEach((insight) => {
       const el = document.createElement('div');
       el.className = 'insight-item';
       el.innerHTML = `<strong>${insight.title}</strong><span>${insight.detail}</span>`;
@@ -38,43 +39,33 @@ function computeInsights() {
   const hour = now.getHours();
   const today = SharedStorage.aggregateDay(now);
   const targets = SharedStorage.getTargets();
-  const waterPct = percent(today.water, targets.water || 1);
-  const sleepHours = today.sleep / 60;
-  const caffeine = today.caffeine;
-  const stepsPct = percent(today.steps, targets.steps || 1);
 
-  if (hour >= 18 && waterPct < 60) {
+  const waterTarget = targets.water_ml || 0;
+  const waterPct = waterTarget ? percent(today.water_ml, waterTarget) : 0;
+  if (hour >= 18 && waterTarget && waterPct < 60) {
+    const remaining = Math.max(0, waterTarget - today.water_ml);
+    const rounded = Math.max(250, Math.round(remaining / 250) * 250);
     insights.push({
-      title: 'Hydration lagging',
-      detail: `Only ${waterPct}% of hydration goal reached. Consider a glass of water to stay on track.`,
+      title: 'Hydration nudge',
+      detail: `Ещё ~${formatNumber(rounded)} ml до цели 💧`,
     });
   }
 
-  if (hour >= 21 && sleepHours < 7) {
+  const desiredSleep = Math.max(420, targets.sleep_min || 0);
+  if (hour >= 21 && today.sleep_min < desiredSleep) {
+    const diffMinutes = Math.max(0, desiredSleep - today.sleep_min);
+    const rounded = Math.max(10, Math.round(diffMinutes / 10) * 10);
     insights.push({
-      title: 'Prepare for better sleep',
-      detail: `Logged ${minutesToHours(today.sleep)} so far. Aim for ${minutesToHours(targets.sleep)} tonight.`,
+      title: 'Sleep prep',
+      detail: `${formatNumber(rounded)} мин до 7 часов 😴`,
     });
   }
 
-  if (caffeine > 300) {
+  const caffeineCap = targets.caffeine_mg || 0;
+  if (caffeineCap && today.caffeine_mg > caffeineCap) {
     insights.push({
-      title: 'Caffeine nearing limit',
-      detail: `You've logged ${caffeine} mg today. Slow down intake to avoid restless sleep.`,
-    });
-  }
-
-  if (stepsPct < 50 && hour >= 15) {
-    insights.push({
-      title: 'Movement break suggested',
-      detail: `Only ${stepsPct}% of your steps goal so far. A short walk could keep the streak alive.`,
-    });
-  }
-
-  if (!insights.length && today.meds === 0 && Array.isArray(targets.meds) && targets.meds.length) {
-    insights.push({
-      title: 'Medication reminder',
-      detail: 'No medications logged yet today. Mark as taken once completed.',
+      title: 'Caffeine check',
+      detail: 'Старайся не превышать норму ☕',
     });
   }
 

--- a/assets/js/quick-actions.js
+++ b/assets/js/quick-actions.js
@@ -8,7 +8,7 @@ const ACTIONS = [
   { id: 'water-500', type: 'water', value: 500, label: '+500 ml water', hint: 'Tall glass' },
   { id: 'steps-1k', type: 'steps', value: 1000, label: '+1k steps', hint: 'Quick walk' },
   { id: 'sleep-8h', type: 'sleep', value: 480, label: '+8h sleep', hint: 'Log rest' },
-  { id: 'meds', type: 'meds', value: 1, label: 'Take meds', hint: 'Mark taken' },
+  { id: 'meds', type: 'med', value: 1, label: 'Take meds', hint: 'Mark taken' },
   { id: 'note', type: 'note', value: null, label: 'Add note', hint: 'Remember this' },
 ];
 

--- a/assets/js/streaks.js
+++ b/assets/js/streaks.js
@@ -1,7 +1,7 @@
 import { SharedStorage } from './sharedStorage.js';
-import { minutesToHours } from './utils.js';
+import { minutesToHours, formatNumber } from './utils.js';
 
-let lastStreaks = { water: 0, steps: 0, sleep: 0 };
+let lastStreaks = { water_ml: 0, steps: 0, sleep_min: 0 };
 
 export function initStreaks() {
   const list = document.getElementById('streak-list');
@@ -13,9 +13,27 @@ export function initStreaks() {
     const streakMap = SharedStorage.streaks(14);
     const entries = Array.from(streakMap.entries());
     const metrics = [
-      { id: 'water', label: 'Hydration streak', target: targets.water, formatter: (value) => `${value} ml` },
-      { id: 'steps', label: 'Steps streak', target: targets.steps, formatter: (value) => `${value} steps` },
-      { id: 'sleep', label: 'Sleep streak', target: targets.sleep, formatter: (value) => minutesToHours(value) },
+      {
+        id: 'water_ml',
+        label: 'Hydration streak',
+        target: targets.water_ml,
+        formatter: (value) => `${formatNumber(value)} ml`,
+        badgeKey: 'water',
+      },
+      {
+        id: 'steps',
+        label: 'Steps streak',
+        target: targets.steps,
+        formatter: (value) => `${formatNumber(value)} steps`,
+        badgeKey: 'steps',
+      },
+      {
+        id: 'sleep_min',
+        label: 'Sleep streak',
+        target: targets.sleep_min,
+        formatter: (value) => minutesToHours(value),
+        badgeKey: 'sleep',
+      },
     ];
 
     list.innerHTML = '';
@@ -28,7 +46,7 @@ export function initStreaks() {
       const row = document.createElement('div');
       row.className = 'streak card-hover';
       row.innerHTML = `
-        <span aria-hidden="true">${metricIcon(metric.id)}</span>
+        <span aria-hidden="true">${metricIcon(metric.badgeKey || metric.id)}</span>
         <div>
           <strong>${metric.label}</strong>
           <div class="timeline-meta">${streakValue} day streak · Today ${metric.formatter(todayValue)}</div>
@@ -65,7 +83,7 @@ function computeStreak(entries, metric, target) {
   let streak = 0;
   for (let i = 0; i < entries.length; i += 1) {
     const value = entries[i][1][metric] || 0;
-    const success = metric === 'caffeine' ? value <= target : value >= target;
+    const success = metric === 'caffeine_mg' ? value <= target : value >= target;
     if (success) {
       streak += 1;
     } else {
@@ -79,11 +97,11 @@ function buildBadges(streaks) {
   const badges = [];
   Object.entries(streaks).forEach(([metric, value]) => {
     if (value >= 14) {
-      badges.push(`${titleCase(metric)} Ascendant`);
+      badges.push(`${friendlyMetricName(metric)} Ascendant`);
     } else if (value >= 7) {
-      badges.push(`${titleCase(metric)} Guardian`);
+      badges.push(`${friendlyMetricName(metric)} Guardian`);
     } else if (value >= 3) {
-      badges.push(`${titleCase(metric)} Builder`);
+      badges.push(`${friendlyMetricName(metric)} Builder`);
     }
   });
   return badges;
@@ -98,10 +116,12 @@ function badgeLabel(streak) {
 
 function metricIcon(metric) {
   switch (metric) {
+    case 'water_ml':
     case 'water':
       return '💧';
     case 'steps':
       return '🔥';
+    case 'sleep_min':
     case 'sleep':
       return '🌙';
     default:
@@ -109,6 +129,15 @@ function metricIcon(metric) {
   }
 }
 
-function titleCase(text) {
-  return text.charAt(0).toUpperCase() + text.slice(1);
+function friendlyMetricName(metric) {
+  switch (metric) {
+    case 'water_ml':
+      return 'Hydration';
+    case 'sleep_min':
+      return 'Sleep';
+    case 'steps':
+      return 'Steps';
+    default:
+      return metric.charAt(0).toUpperCase() + metric.slice(1);
+  }
 }

--- a/assets/js/summary-header.js
+++ b/assets/js/summary-header.js
@@ -58,8 +58,8 @@ export function initHeader() {
     const now = new Date();
     const dateLabel = formatDateRange(now);
     const city = settings.city ? ` · ${settings.city}` : '';
-    const battery = settings.deviceBattery ?? 0;
-    const lastPing = settings.lastDevicePing ? new Date(settings.lastDevicePing) : null;
+    const battery = settings.batteryPct;
+    const lastPing = settings.lastDevicePingISO ? new Date(settings.lastDevicePingISO) : null;
     const status = computeDeviceStatus(lastPing);
 
     const dateEl = container.querySelector('[data-date]');
@@ -71,7 +71,7 @@ export function initHeader() {
 
     if (dateEl) dateEl.textContent = dateLabel;
     if (cityEl) cityEl.textContent = city;
-    if (batteryEl) batteryEl.textContent = `${battery}%`;
+    if (batteryEl) batteryEl.textContent = Number.isFinite(battery) ? `${battery}%` : '—';
     if (statusEl) statusEl.dataset.state = status.color;
     if (statusIconEl) statusIconEl.textContent = status.icon;
     if (statusLabelEl) statusLabelEl.textContent = status.label;

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -8,7 +8,7 @@ const RANGE_OPTIONS = [
   { id: '7d', label: '7d', heading: 'Last 7 days', days: 7 },
   { id: '30d', label: '30d', heading: 'Last 30 days', days: 30 },
 ];
-const TYPE_OPTIONS = ['water', 'steps', 'sleep', 'caffeine', 'meds', 'note'];
+const TYPE_OPTIONS = ['water', 'steps', 'sleep', 'caffeine', 'med', 'note'];
 
 let currentRange = RANGE_OPTIONS[0];
 

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -30,34 +30,29 @@ export function percent(value, target) {
 }
 
 export function statusFromRules(type, total, target, context = {}) {
+  const pct = target ? percent(total, target) : 0;
   switch (type) {
-    case 'hydration': {
-      if (total >= target) return 'on-track';
-      if (percent(total, target) < 60) return 'warning';
-      return 'progress';
-    }
-    case 'sleep': {
-      const hours = total / 60;
-      if (hours >= 7) return 'on-track';
-      if (hours < 6) return 'warning';
-      return 'progress';
-    }
+    case 'hydration':
+    case 'sleep':
     case 'steps': {
-      if (total >= 8000) return 'on-track';
-      if (total < 5000) return 'warning';
-      return 'progress';
+      if (!target) return 'neutral';
+      if (pct >= 100) return 'on-track';
+      if (pct >= 60) return 'warning';
+      return 'danger';
     }
     case 'caffeine': {
-      if (total > 300) return 'warning';
-      if (total > target) return 'warning';
-      return 'on-track';
+      if (!target) return 'neutral';
+      const ratio = target ? total / target : 0;
+      if (ratio <= 0.8) return 'on-track';
+      if (ratio <= 1) return 'warning';
+      return 'danger';
     }
     case 'meds': {
-      if (context.missed) return 'danger';
-      return context.medsTaken ? 'on-track' : 'progress';
+      if (!context.totalScheduled) return 'neutral';
+      return context.medsTaken >= context.totalScheduled ? 'on-track' : 'danger';
     }
     default:
-      return 'progress';
+      return 'neutral';
   }
 }
 
@@ -84,7 +79,7 @@ export function iconForType(type) {
       return '🌙';
     case 'caffeine':
       return '☕';
-    case 'meds':
+    case 'med':
       return '💊';
     default:
       return '🧠';
@@ -101,6 +96,8 @@ export function unitLabel(type) {
       return 'min';
     case 'caffeine':
       return 'mg';
+    case 'med':
+      return 'dose';
     default:
       return '';
   }


### PR DESCRIPTION
## Summary
- resolve Summary.html assets through a base-aware loader so CSS and scripts hydrate without 404s
- migrate shared storage to the new targets/meds schema and expose helpers for meds_today updates
- refresh summary modules (hero KPI, rings, sidebar, quick actions, insights, streaks, timeline, dev seed) to use the new fields and status logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6ca49a08c8332a6d5e7b8ce7e04cd