### PR TITLE
Add shared sidenav loader and refresh Summary hero layout

### DIFF
--- a/DiaryPlus.html
+++ b/DiaryPlus.html
@@ -9,7 +9,7 @@
 
 </head>
   <body class="app-shell" data-page="diary">
-    <div data-include="nav"></div>
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
     <main class="app-main">
       <div class="container flow">
         <header class="page-header">
@@ -79,9 +79,11 @@
 
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
-    <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
+    <script src="./shared/storage.js" defer></script>
+    <script src="./assets/js/includes.js" defer></script>
+    <script>
+      window.addEventListener('load', () => console.log('TopBar type:', typeof window.H2099TopBar));
+    </script>
     <script>
       (function () {
         const form = document.getElementById('event-form');

--- a/HealthCabinet.html
+++ b/HealthCabinet.html
@@ -9,7 +9,7 @@
 
 </head>
   <body class="app-shell" data-page="health">
-    <div data-include="nav"></div>
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
     <main class="app-main">
       <div class="container flow health-dashboard" data-health-dashboard>
         <header class="page-header">
@@ -26,9 +26,11 @@
       </div>
     </main>
 
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
-    <script>window.addEventListener('load',()=>console.log('TopBar type:', typeof window.H2099TopBar));</script>
+    <script src="./shared/storage.js" defer></script>
+    <script src="./assets/js/includes.js" defer></script>
+    <script>
+      window.addEventListener('load', () => console.log('TopBar type:', typeof window.H2099TopBar));
+    </script>
     <script type="module" src="./health/health-cabinet-page.js"></script>
   </body>
 </html>

--- a/Map.html
+++ b/Map.html
@@ -19,7 +19,7 @@
     ></script>
   </head>
   <body class="app-shell" data-page="map">
-    <div data-include="nav"></div>
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
     <main class="app-main">
       <div class="container flow">
         <header class="page-header">
@@ -62,8 +62,7 @@
         </div>
       </div>
     </main>
-
-    <script src="./shared/nav-loader.js" defer></script>
+    <script src="./assets/js/includes.js" defer></script>
     <script>
       (function () {
         const LS_LOCATIONS = 'health_locations_v1';

--- a/Summary.html
+++ b/Summary.html
@@ -4,207 +4,105 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#2563eb" />
-    <link rel="manifest" data-asset="href" data-href="manifest.webmanifest" />
-    <link rel="preload" data-asset="href" data-href="assets/css/summary.css?v=20240714" as="style" />
-    <link rel="preload" data-asset="href" data-href="assets/css/animations.css?v=20240714" as="style" />
-    <link rel="preload" data-asset="href" data-href="assets/css/timeline.css?v=20240714" as="style" />
-    <link rel="preload" data-asset="href" data-href="assets/css/kpi-rings.css?v=20240714" as="style" />
-    <link rel="preload" data-asset="href" data-href="assets/css/ui.css?v=20240714" as="style" />
-    <style>
-      :root {
-        color-scheme: dark;
-        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-      }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        background: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.18), transparent 55%),
-          radial-gradient(circle at 80% 0%, rgba(15, 118, 110, 0.28), transparent 60%),
-          linear-gradient(160deg, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 1) 100%);
-        color: #f8fafc;
-      }
-      .app-shell {
-        display: grid;
-        min-height: 100vh;
-        grid-template-rows: auto 1fr auto;
-      }
-      .summary-viewport {
-        max-width: 1280px;
-        margin: 0 auto;
-        width: 100%;
-        padding: clamp(1.5rem, 2vw, 3rem) clamp(1rem, 2vw, 3rem) 3rem;
-        display: grid;
-        gap: 1.75rem;
-      }
-      .summary-header,
-      .summary-main,
-      .summary-sidebar {
-        background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(15, 23, 42, 0.58));
-        border-radius: 24px;
-        border: 1px solid rgba(96, 165, 250, 0.18);
-        box-shadow: 0 12px 48px rgba(2, 6, 23, 0.38);
-        backdrop-filter: blur(28px);
-        -webkit-backdrop-filter: blur(28px);
-      }
-      .summary-header {
-        padding: 2.5rem clamp(2rem, 3vw, 3rem);
-      }
-      .summary-main {
-        padding: clamp(1.75rem, 2vw, 2.5rem);
-        display: grid;
-        gap: 1.75rem;
-      }
-      .summary-sidebar {
-        padding: clamp(1.5rem, 2vw, 2.25rem);
-        display: grid;
-        gap: 1.5rem;
-        align-content: start;
-      }
-      @media (min-width: 960px) {
-        .summary-viewport {
-          grid-template-columns: 2fr 1fr;
-          align-items: start;
-        }
-      }
-    </style>
-    <link rel="stylesheet" data-asset="href" data-href="assets/css/theme.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" data-asset="href" data-href="assets/css/summary.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" data-asset="href" data-href="assets/css/animations.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" data-asset="href" data-href="assets/css/timeline.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" data-asset="href" data-href="assets/css/kpi-rings.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" data-asset="href" data-href="assets/css/ui.css?v=20240714" media="print" onload="this.media='all'" />
-    <link rel="stylesheet" data-asset="href" data-href="assets/css/badges.css?v=20240714" media="print" onload="this.media='all'" />
-    <script>
-      (function () {
-        const ABSOLUTE = /^(?:[a-z]+:)?\/\//i;
-        function ensureTrailingSlash(value) {
-          if (!value) return '/';
-          return value.endsWith('/') ? value : `${value}/`;
-        }
-        function computeBase() {
-          const fromGlobal = typeof window.__HEALTH2099_BASE__ === 'string' ? window.__HEALTH2099_BASE__ : null;
-          if (fromGlobal) return ensureTrailingSlash(fromGlobal);
-          const { pathname } = window.location;
-          const base = pathname.endsWith('/') ? pathname : pathname.replace(/[^/]*$/, '');
-          return ensureTrailingSlash(base);
-        }
-        const basePath = computeBase();
-        function withBase(path) {
-          if (!path || ABSOLUTE.test(path)) return path;
-          if (path.startsWith('/')) return path;
-          return `${basePath}${path.replace(/^\.\//, '')}`;
-        }
-        window.__HEALTH2099_BASE__ = basePath;
-        window.__HEALTH2099_WITH_BASE__ = withBase;
-        function applyAssets() {
-          const nodes = document.querySelectorAll('[data-asset]');
-          nodes.forEach((node) => {
-            const attr = node.getAttribute('data-asset');
-            const original = node.getAttribute(`data-${attr}`);
-            if (!attr || !original) return;
-            const value = withBase(original);
-            if (attr === 'href') {
-              node.setAttribute('href', value);
-            } else if (attr === 'src') {
-              node.setAttribute('src', value);
-            }
-          });
-        }
-        const observer = new MutationObserver(() => applyAssets());
-        observer.observe(document.documentElement, { childList: true, subtree: true });
-        document.addEventListener('DOMContentLoaded', () => {
-          applyAssets();
-          observer.disconnect();
-        });
-        applyAssets();
-      })();
-    </script>
-    <noscript>
-      <link rel="stylesheet" href="assets/css/theme.css?v=20240714" />
-      <link rel="stylesheet" href="assets/css/summary.css?v=20240714" />
-      <link rel="stylesheet" href="assets/css/animations.css?v=20240714" />
-      <link rel="stylesheet" href="assets/css/timeline.css?v=20240714" />
-      <link rel="stylesheet" href="assets/css/badges.css?v=20240714" />
-      <link rel="stylesheet" href="assets/css/kpi-rings.css?v=20240714" />
-      <link rel="stylesheet" href="assets/css/ui.css?v=20240714" />
-    </noscript>
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./shared/styles.css" />
+    <link rel="stylesheet" href="./assets/css/summary.css?v=20240714" />
+    <link rel="stylesheet" href="./assets/css/animations.css?v=20240714" />
+    <link rel="stylesheet" href="./assets/css/timeline.css?v=20240714" />
+    <link rel="stylesheet" href="./assets/css/kpi-rings.css?v=20240714" />
+    <link rel="stylesheet" href="./assets/css/ui.css?v=20240714" />
+    <link rel="stylesheet" href="./assets/css/badges.css?v=20240714" />
   </head>
   <body class="app-shell" data-page="summary">
-    <div data-include="nav"></div>
-    <div class="summary-viewport">
-      <header id="summary-header" class="summary-header" role="banner"></header>
-      <main class="summary-main" id="main" role="main">
-        <section aria-labelledby="kpi-heading" class="kpi-grid" id="kpi-grid" role="region" data-kpi-rings>
-          <h2 id="kpi-heading" class="visually-hidden">Key wellness metrics</h2>
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
+    <main class="app-main">
+      <div class="summary-viewport">
+        <section class="hero hero--summary rounded-3xl">
+          <div class="hero__overline">SUMMARY</div>
+          <h1 class="hero__title">Wellness snapshot</h1>
+          <p class="hero__subtitle">
+            Live overview of hydration, sleep, steps, caffeine and meds. Everything updates live across tabs.
+          </p>
         </section>
-        <section class="quick-actions" aria-labelledby="actions-heading" role="region">
-          <header>
-            <h2 id="actions-heading">Quick actions</h2>
-            <p>Log habits in a tap. Offline entries queue automatically.</p>
-          </header>
-          <div class="quick-actions__grid" id="quick-actions" role="group" aria-label="Quick log actions"></div>
-        </section>
-        <section class="timeline" aria-labelledby="timeline-heading" role="region">
-          <header class="timeline__header">
-            <div class="timeline__title">
-              <h2 id="timeline-heading">Today</h2>
-              <p id="timeline-count" class="timeline-meta"></p>
-            </div>
-            <div class="timeline__controls">
-              <div class="timeline-filters" id="timeline-filters" role="group" aria-label="Timeline range"></div>
-              <button type="button" class="card-press" id="seed-demo">Seed demo data</button>
-            </div>
-          </header>
-          <div class="timeline-list" id="timeline-list" aria-live="polite"></div>
-        </section>
-        <section class="insights" aria-labelledby="insights-heading" id="insights" role="region">
-          <h2 id="insights-heading">Insights &amp; nudges</h2>
-        </section>
-        <section class="streaks" aria-labelledby="streaks-heading" role="region">
-          <h2 id="streaks-heading">Streaks</h2>
-          <div class="streak-list" id="streak-list"></div>
-        </section>
-        <section class="badges" aria-labelledby="badges-heading" role="region">
-          <h2 id="badges-heading" class="visually-hidden">Badges</h2>
-          <div id="badge-collection"></div>
-        </section>
-      </main>
-      <aside class="summary-sidebar" aria-labelledby="sidebar-heading">
-        <h2 id="sidebar-heading" class="visually-hidden">Sidebar</h2>
-        <section class="sidebar-section" aria-labelledby="targets-heading">
-          <header>
-            <h3 id="targets-heading">Targets</h3>
-          </header>
-          <div class="target-item">
-            <label for="target-water">Water goal (ml)</label>
-            <input id="target-water" type="number" inputmode="numeric" min="0" />
+        <div class="summary-layout">
+          <div class="summary-content">
+            <header id="summary-header" class="summary-header" role="banner"></header>
+            <section class="summary-main" id="main">
+              <section aria-labelledby="kpi-heading" class="kpi-grid" id="kpi-grid" role="region" data-kpi-rings>
+                <h2 id="kpi-heading" class="visually-hidden">Key wellness metrics</h2>
+              </section>
+              <section class="quick-actions" aria-labelledby="actions-heading" role="region">
+                <header>
+                  <h2 id="actions-heading">Quick actions</h2>
+                  <p>Log habits in a tap. Offline entries queue automatically.</p>
+                </header>
+                <div class="quick-actions__grid" id="quick-actions" role="group" aria-label="Quick log actions"></div>
+              </section>
+              <section class="timeline" aria-labelledby="timeline-heading" role="region">
+                <header class="timeline__header">
+                  <div class="timeline__title">
+                    <h2 id="timeline-heading">Today</h2>
+                    <p id="timeline-count" class="timeline-meta"></p>
+                  </div>
+                  <div class="timeline__controls">
+                    <div class="timeline-filters" id="timeline-filters" role="group" aria-label="Timeline range"></div>
+                    <button type="button" class="card-press" id="seed-demo">Seed demo data</button>
+                  </div>
+                </header>
+                <div class="timeline-list" id="timeline-list" aria-live="polite"></div>
+              </section>
+              <section class="insights" aria-labelledby="insights-heading" id="insights" role="region">
+                <h2 id="insights-heading">Insights &amp; nudges</h2>
+              </section>
+              <section class="streaks" aria-labelledby="streaks-heading" role="region">
+                <h2 id="streaks-heading">Streaks</h2>
+                <div class="streak-list" id="streak-list"></div>
+              </section>
+              <section class="badges" aria-labelledby="badges-heading" role="region">
+                <h2 id="badges-heading" class="visually-hidden">Badges</h2>
+                <div id="badge-collection"></div>
+              </section>
+            </section>
           </div>
-          <div class="target-item">
-            <label for="target-steps">Steps goal</label>
-            <input id="target-steps" type="number" inputmode="numeric" min="0" />
-          </div>
-          <div class="target-item">
-            <label for="target-sleep">Sleep goal (minutes)</label>
-            <input id="target-sleep" type="number" inputmode="numeric" min="0" />
-          </div>
-          <div class="target-item">
-            <label for="target-caffeine">Caffeine ceiling (mg)</label>
-            <input id="target-caffeine" type="number" inputmode="numeric" min="0" />
-          </div>
-        </section>
-        <section class="sidebar-section" aria-labelledby="meds-heading">
-          <header>
-            <h3 id="meds-heading">Today&apos;s meds</h3>
-            <button type="button" id="add-med" class="card-press">Add</button>
-          </header>
-          <div class="meds-list" id="meds-list" aria-live="polite"></div>
-        </section>
-      </aside>
-    </div>
-    <footer class="summary-footer" role="contentinfo">
-      Synced via shared storage · Broadcast ready
-    </footer>
-    <script data-asset="src" data-src="shared/nav-loader.js" defer></script>
-    <script type="module" data-asset="src" data-src="assets/js/summary-page.js?v=20240714" defer></script>
+          <aside class="summary-sidebar" aria-labelledby="sidebar-heading">
+            <h2 id="sidebar-heading" class="visually-hidden">Sidebar</h2>
+            <section class="sidebar-section" aria-labelledby="targets-heading">
+              <header>
+                <h3 id="targets-heading">Targets</h3>
+              </header>
+              <div class="target-item">
+                <label for="target-water">Water goal (ml)</label>
+                <input id="target-water" type="number" inputmode="numeric" min="0" />
+              </div>
+              <div class="target-item">
+                <label for="target-steps">Steps goal</label>
+                <input id="target-steps" type="number" inputmode="numeric" min="0" />
+              </div>
+              <div class="target-item">
+                <label for="target-sleep">Sleep goal (minutes)</label>
+                <input id="target-sleep" type="number" inputmode="numeric" min="0" />
+              </div>
+              <div class="target-item">
+                <label for="target-caffeine">Caffeine ceiling (mg)</label>
+                <input id="target-caffeine" type="number" inputmode="numeric" min="0" />
+              </div>
+            </section>
+            <section class="sidebar-section" aria-labelledby="meds-heading">
+              <header>
+                <h3 id="meds-heading">Today&apos;s meds</h3>
+                <button type="button" id="add-med" class="card-press">Add</button>
+              </header>
+              <div class="meds-list" id="meds-list" aria-live="polite"></div>
+            </section>
+          </aside>
+        </div>
+        <footer class="summary-footer" role="contentinfo">
+          Synced via shared storage · Broadcast ready
+        </footer>
+      </div>
+    </main>
+    <script src="./shared/storage.js" defer></script>
+    <script src="./assets/js/includes.js" defer></script>
+    <script type="module" src="./assets/js/summary-page.js?v=20240714"></script>
   </body>
 </html>

--- a/assets/css/summary.css
+++ b/assets/css/summary.css
@@ -2,23 +2,100 @@
   --container-max: 1280px;
 }
 
-.app-shell {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  min-height: 100vh;
+body[data-page='summary'] {
+  --text: var(--color-heading);
+  --muted: var(--color-muted);
+  --primary: var(--color-primary);
+  --ok: var(--color-success);
+  --warn: var(--color-warning);
+  --danger: var(--color-danger);
+  --radius: var(--radius-lg);
+  --shadow-soft: var(--shadow-sm);
+  --backdrop-blur: var(--glass-blur);
+  --glass-border: 1px solid var(--glass-border-color);
+  --glass-gradient: linear-gradient(135deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
 }
 
 .summary-viewport {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.75rem;
-  padding: clamp(1.5rem, 2vw, 3rem) clamp(1rem, 2vw, 3rem) 3rem;
-  max-width: var(--container-max);
+  gap: var(--space-5);
+  padding: clamp(var(--space-5), 2vw + var(--space-4), var(--space-7));
+  width: min(var(--container-max), 100%);
   margin: 0 auto;
-  width: 100%;
 }
 
-.summary-main,
+.summary-layout {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.summary-content {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  gap: var(--space-3);
+  padding: clamp(var(--space-6), 2vw + var(--space-5), var(--space-7));
+  background: linear-gradient(135deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: auto -35% -45% auto;
+  width: min(420px, 60vw);
+  height: min(420px, 60vw);
+  background: radial-gradient(circle at center, rgba(96, 165, 250, 0.3), transparent 60%);
+  filter: blur(0px);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.hero__overline {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  color: var(--color-muted);
+}
+
+.hero__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 3vw + 1.2rem, 3.6rem);
+  font-weight: 700;
+  color: var(--color-heading);
+}
+
+.hero__subtitle {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--color-muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.hero--summary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(59, 130, 246, 0.08)),
+    linear-gradient(135deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  box-shadow: var(--shadow-sm), 0 45px 120px rgba(37, 99, 235, 0.25);
+}
+
+.hero--summary::after {
+  background: radial-gradient(circle at 30% 10%, rgba(96, 165, 250, 0.35), transparent 60%),
+    radial-gradient(circle at 85% 0%, rgba(14, 165, 233, 0.28), transparent 65%);
+}
+
+.rounded-3xl {
+  border-radius: var(--radius-lg);
+}
+
 .summary-sidebar,
 .summary-header,
 .summary-footer,
@@ -38,7 +115,7 @@
 }
 
 .summary-header {
-  padding: 2.5rem clamp(2rem, 3vw, 3rem);
+  padding: clamp(var(--space-5), 2vw + var(--space-4), var(--space-6)) clamp(var(--space-5), 3vw + var(--space-4), var(--space-6));
   display: grid;
   gap: 1.5rem;
   overflow: hidden;
@@ -360,26 +437,15 @@
   color: var(--danger);
 }
 
-.summary-grid {
-  display: grid;
-  gap: 1.75rem;
-}
-
-.summary-columns {
-  display: grid;
-  gap: 1.75rem;
-}
-
 .summary-main {
-  padding: clamp(1.75rem, 2vw, 2.5rem);
   display: grid;
-  gap: 1.75rem;
+  gap: var(--space-5);
 }
 
 .summary-sidebar {
-  padding: clamp(1.5rem, 2vw, 2.25rem);
+  padding: clamp(var(--space-5), 2vw + var(--space-4), var(--space-6));
   display: grid;
-  gap: 1.5rem;
+  gap: var(--space-4);
   align-content: start;
 }
 
@@ -610,28 +676,19 @@
 }
 
 @media (min-width: 960px) {
-  .summary-viewport {
-    grid-template-columns: 2fr 1fr;
+  .summary-layout {
+    grid-template-columns: minmax(0, 8fr) minmax(0, 4fr);
     align-items: start;
-  }
-
-  .summary-columns {
-    grid-template-columns: 2fr 1fr;
-  }
-
-  .summary-main {
-    order: 1;
   }
 
   .summary-sidebar {
     position: sticky;
-    top: 120px;
+    top: clamp(96px, 6vw + 48px, 140px);
   }
 }
 
 @media (max-width: 959px) {
   .summary-header,
-  .summary-main,
   .summary-sidebar,
   .summary-footer,
   .quick-actions,

--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -1,0 +1,110 @@
+(function () {
+  const ABSOLUTE_URL = /^(?:[a-z]+:)?\/\//i;
+  const HOST_ID = 'sidenav';
+  const TOPBAR_SCRIPT_ID = 'topbar-bundle';
+  const TOPBAR_PATH = '/assets/topbar.bundle.js?v=8';
+
+  function normalizeBase(value) {
+    if (!value || typeof value !== 'string') return '';
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+  }
+
+  function computeBase() {
+    if (typeof window === 'undefined') return '';
+    const doc = typeof document !== 'undefined' ? document : null;
+    const candidates = [
+      window.BASE,
+      window.__HEALTH2099_BASE__,
+      doc?.documentElement?.dataset?.base,
+      doc?.querySelector('meta[name="health-base"]')?.getAttribute('content'),
+    ];
+
+    for (const candidate of candidates) {
+      if (candidate && typeof candidate === 'string') {
+        return normalizeBase(candidate);
+      }
+    }
+
+    const pathname = window.location?.pathname || '';
+    if (!pathname || pathname === '/') return '';
+    if (pathname.endsWith('/')) {
+      return normalizeBase(pathname.slice(0, -1));
+    }
+    return normalizeBase(pathname.replace(/\/?[^/]*$/, ''));
+  }
+
+  const basePath = computeBase();
+  if (typeof window !== 'undefined') {
+    window.BASE = basePath;
+  }
+
+  function withBase(path) {
+    if (!path || typeof path !== 'string' || ABSOLUTE_URL.test(path)) {
+      return path;
+    }
+    const cleaned = path.replace(/^\.\//, '');
+    if (path.startsWith('/')) {
+      return `${basePath}${path}` || path;
+    }
+    const prefix = basePath ? `${basePath}/${cleaned}` : `/${cleaned}`;
+    return prefix.replace(/\/\/{2,}/g, '/');
+  }
+
+  if (typeof window !== 'undefined') {
+    window.withBase = window.withBase || withBase;
+  }
+
+  function ensureTopbar() {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(TOPBAR_SCRIPT_ID)) return;
+    const script = document.createElement('script');
+    script.id = TOPBAR_SCRIPT_ID;
+    script.defer = true;
+    script.src = withBase(TOPBAR_PATH);
+    document.head.appendChild(script);
+  }
+
+  function highlightActive(container) {
+    if (!container || typeof document === 'undefined') return;
+    const path = (window.location?.pathname || '').toLowerCase();
+    container.querySelectorAll('a[data-route]').forEach((link) => {
+      const route = link.dataset.route ? link.dataset.route.toLowerCase() : '';
+      const isActive = route && path.includes(route);
+      link.classList.toggle('is-active', Boolean(isActive));
+      if (isActive) {
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  function injectSidenav() {
+    if (typeof document === 'undefined') return;
+    const host = document.getElementById(HOST_ID);
+    if (!host) return;
+    ensureTopbar();
+    fetch(withBase('/partials/sidenav.html'))
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch sidenav include: ${response.status}`);
+        }
+        return response.text();
+      })
+      .then((html) => {
+        host.innerHTML = html;
+        highlightActive(host);
+      })
+      .catch((error) => {
+        console.error('[includes] Unable to inject sidenav', error);
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectSidenav, { once: true });
+  } else {
+    injectSidenav();
+  }
+})();

--- a/partials/sidenav.html
+++ b/partials/sidenav.html
@@ -1,0 +1,21 @@
+<div class="brand">
+  <a class="brand-link" href="Summary.html">Health • 2099</a>
+</div>
+<nav class="nav" aria-label="Primary navigation">
+  <a class="nav-link" data-route="summary" href="Summary.html">
+    <span aria-hidden="true">📈</span>
+    <span>Summary</span>
+  </a>
+  <a class="nav-link" data-route="health" href="HealthCabinet.html">
+    <span aria-hidden="true">🧬</span>
+    <span>Health cabinet</span>
+  </a>
+  <a class="nav-link" data-route="diary" href="DiaryPlus.html">
+    <span aria-hidden="true">📝</span>
+    <span>Diary</span>
+  </a>
+  <a class="nav-link" data-route="map" href="Map.html">
+    <span aria-hidden="true">🗺️</span>
+    <span>Map</span>
+  </a>
+</nav>

--- a/pocket_health_link.html
+++ b/pocket_health_link.html
@@ -7,10 +7,9 @@
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="./manifest.webmanifest" />
     <link rel="stylesheet" href="./shared/styles.css" />
-  <script src="/Health2099/assets/topbar.bundle.js?v=6" defer></script>
   </head>
   <body class="app-shell" data-page="links">
-    <div data-include="nav"></div>
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
     <main class="app-main">
       <div class="container">
         <div class="link-grid">
@@ -32,8 +31,8 @@
         </div>
       </div>
     </main>
-    <script src="./shared/storage.js"></script>
-    <script src="./shared/nav-loader.js"></script>
+    <script src="./shared/storage.js" defer></script>
+    <script src="./assets/js/includes.js" defer></script>
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -213,7 +213,8 @@ a:focus {
   outline: none;
 }
 
-.nav-link.active {
+.nav-link.active,
+.nav-link.is-active {
   background: var(--color-nav-active-bg);
   border: 1px solid var(--color-nav-active-border);
   color: var(--color-nav-active-text);


### PR DESCRIPTION
## Summary
- replace the old inline navigation loader with a reusable `includes.js` helper and HTML partial so every page renders the same SideNav and active-state styling
- restyle Summary.html to include the shared SideNav, a new hero banner, and an 8/12 + 4/12 content grid that matches Health Cabinet spacing
- map Summary CSS tokens onto the shared theme palette so glass panels, cards, and hero styling reuse the common design language

## Testing
- Manual: opened `Summary.html` via `python -m http.server 8000` and verified the SideNav loaded without console errors

------
https://chatgpt.com/codex/tasks/task_e_68e73f67c428833287cbf140284a6f61