### PR TITLE
Refactor summary storage and script wiring

### DIFF
--- a/Summary.html
+++ b/Summary.html
@@ -5,20 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="preload" href="./assets/css/theme.css" as="style" />
+    <link rel="stylesheet" href="./assets/css/theme.css" />
     <link rel="stylesheet" href="./shared/styles.css" />
-    <link rel="stylesheet" href="./assets/css/summary.css?v=20240714" />
-    <link rel="stylesheet" href="./assets/css/animations.css?v=20240714" />
-    <link rel="stylesheet" href="./assets/css/timeline.css?v=20240714" />
-    <link rel="stylesheet" href="./assets/css/kpi-rings.css?v=20240714" />
-    <link rel="stylesheet" href="./assets/css/ui.css?v=20240714" />
-    <link rel="stylesheet" href="./assets/css/badges.css?v=20240714" />
+    <link rel="stylesheet" href="./assets/css/summary.css?v=20240716" />
+    <link rel="stylesheet" href="./assets/css/animations.css?v=20240716" />
+    <link rel="stylesheet" href="./assets/css/timeline.css?v=20240716" />
+    <link rel="stylesheet" href="./assets/css/ui.css?v=20240716" />
+    <link rel="stylesheet" href="./assets/css/badges.css?v=20240716" />
   </head>
   <body class="app has-sidenav app-shell" data-page="summary">
     <div class="app__grid">
       <aside id="sidenav" class="sidebar app__sidenav" aria-label="Primary navigation"></aside>
       <main class="app__main app-main">
         <div class="summary-viewport">
-          <section class="hero">
+          <section class="hero hero--compact">
             <div class="hero__overline">SUMMARY</div>
             <h1 class="hero__title">Wellness snapshot</h1>
             <p class="hero__subtitle">
@@ -103,8 +104,6 @@
         </div>
       </main>
     </div>
-    <script src="./shared/storage.js" defer></script>
-    <script src="./assets/js/includes.js" defer></script>
-    <script type="module" src="./assets/js/summary-page.js?v=20240714"></script>
+    <script type="module" src="./assets/js/summary-page.js?v=20240716"></script>
   </body>
 </html>

--- a/assets/css/summary.css
+++ b/assets/css/summary.css
@@ -46,6 +46,22 @@ body[data-page='summary'] {
   overflow: hidden;
 }
 
+.hero--compact {
+  padding: clamp(16px, 3vw, 32px) clamp(16px, 3vw, 32px);
+  min-height: unset;
+}
+
+.hero--compact .hero__title {
+  font-size: clamp(28px, 3.2vw, 44px);
+  line-height: 1.15;
+  margin-bottom: 8px;
+}
+
+.hero--compact .hero__subtitle {
+  max-width: 72ch;
+  opacity: 0.9;
+}
+
 .hero::after {
   content: '';
   position: absolute;

--- a/assets/js/data-layer.js
+++ b/assets/js/data-layer.js
@@ -1,0 +1,176 @@
+import { getDB, setDB, listLogs } from './sharedStorage.js';
+
+const DEFAULT_SETTINGS = { tz: 'Europe/Amsterdam', lastDevicePingISO: null, batteryPct: null };
+
+export function getSettings() {
+  const db = getDB();
+  return { ...DEFAULT_SETTINGS, ...(db.settings || {}) };
+}
+
+export function setSettings(patch) {
+  const db = getDB();
+  const next = { ...DEFAULT_SETTINGS, ...(db.settings || {}), ...(patch || {}) };
+  setDB({ ...db, settings: next });
+  return { ...next };
+}
+
+export function getMedsToday() {
+  const db = getDB();
+  return Array.isArray(db.meds_today) ? db.meds_today.map((item) => ({ ...item })) : [];
+}
+
+export function setMedsToday(items) {
+  const db = getDB();
+  const meds = Array.isArray(items)
+    ? items.map((item) => ({ id: ensureMedId(item.id), title: item.title || '', taken: Boolean(item.taken) }))
+    : [];
+  setDB({ ...db, meds_today: meds });
+  return meds.map((item) => ({ ...item }));
+}
+
+export function updateMedToday(id, patch) {
+  if (!id) return null;
+  const meds = getMedsToday();
+  let updated = null;
+  const next = meds.map((item) => {
+    if (item.id !== id) return item;
+    updated = { ...item, ...(patch || {}) };
+    return updated;
+  });
+  if (updated) {
+    setMedsToday(next);
+  }
+  return updated;
+}
+
+export function startOfDayISO(date = new Date(), tz = getTimezone()) {
+  return startOfDay(date, tz).toISOString();
+}
+
+export function aggregateDay(date = new Date()) {
+  const tz = getTimezone();
+  const start = startOfDay(date, tz);
+  const end = endOfDay(date, tz);
+  return aggregateRange(start, end);
+}
+
+export function aggregateRange(start, end) {
+  const startDate = start instanceof Date ? start : new Date(start);
+  const endDate = end instanceof Date ? end : new Date(end);
+  const startTime = startDate.getTime();
+  const endTime = endDate.getTime();
+  const totals = {
+    water_ml: 0,
+    steps: 0,
+    sleep_min: 0,
+    caffeine_mg: 0,
+    meds_taken: 0,
+  };
+  listLogs().forEach((log) => {
+    const time = new Date(log.createdAt).getTime();
+    if (Number.isNaN(time)) return;
+    if (time < startTime || time > endTime) return;
+    const value = Number(log.value) || 0;
+    switch (log.type) {
+      case 'water':
+        totals.water_ml += value;
+        break;
+      case 'steps':
+        totals.steps += value;
+        break;
+      case 'sleep':
+        totals.sleep_min += value;
+        break;
+      case 'caffeine':
+        totals.caffeine_mg += value;
+        break;
+      case 'med':
+        totals.meds_taken += 1;
+        break;
+      default:
+        break;
+    }
+  });
+  return totals;
+}
+
+export function streaks(days = 14) {
+  const tz = getTimezone();
+  const map = new Map();
+  for (let i = 0; i < days; i += 1) {
+    const reference = new Date(Date.now() - i * 86400000);
+    const day = startOfDay(reference, tz);
+    map.set(day.toISOString(), aggregateDay(day));
+  }
+  return map;
+}
+
+export function getTimezone() {
+  const settings = getSettings();
+  if (settings.tz) return settings.tz;
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch (error) {
+    return 'UTC';
+  }
+}
+
+function ensureMedId(id) {
+  if (id) return id;
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `med_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+function startOfDay(date, tz = getTimezone()) {
+  try {
+    const parts = zonedParts(date, tz);
+    return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 0, 0, 0, 0));
+  } catch (error) {
+    const next = new Date(date);
+    next.setHours(0, 0, 0, 0);
+    return next;
+  }
+}
+
+function endOfDay(date, tz = getTimezone()) {
+  try {
+    const parts = zonedParts(date, tz);
+    return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 23, 59, 59, 999));
+  } catch (error) {
+    const next = new Date(date);
+    next.setHours(23, 59, 59, 999);
+    return next;
+  }
+}
+
+function zonedParts(date, tz) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(date);
+  const result = {
+    year: 1970,
+    month: 1,
+    day: 1,
+    hour: 0,
+    minute: 0,
+    second: 0,
+  };
+  parts.forEach((part) => {
+    if (part.type === 'literal') return;
+    const value = Number(part.value);
+    if (Number.isFinite(value)) {
+      result[part.type] = value;
+    }
+  });
+  return result;
+}

--- a/assets/js/dev-seed.js
+++ b/assets/js/dev-seed.js
@@ -1,4 +1,5 @@
-import { SharedStorage } from './sharedStorage.js';
+import { pushLog } from './sharedStorage.js';
+import { setSettings, setMedsToday } from './data-layer.js';
 
 export function initDevSeed() {
   const button = document.getElementById('seed-demo');
@@ -19,14 +20,19 @@ export function initDevSeed() {
       });
     }
     entries.forEach((entry) => {
-      SharedStorage.pushLog(entry.type, entry.value, { createdAt: entry.createdAt, note: entry.note });
+      pushLog({
+        type: entry.type,
+        value: entry.value,
+        note: entry.note,
+        createdAt: entry.createdAt,
+      });
     });
-    SharedStorage.setSettings({
+    setSettings({
       city: 'Amsterdam',
       batteryPct: 82,
       lastDevicePingISO: new Date().toISOString(),
     });
-    SharedStorage.setMedsToday([
+    setMedsToday([
       { id: 'med_demo_1', title: 'Morning med', taken: true },
       { id: 'med_demo_2', title: 'Evening med', taken: false },
     ]);

--- a/assets/js/hero-kpi.js
+++ b/assets/js/hero-kpi.js
@@ -1,4 +1,5 @@
-import { SharedStorage } from './sharedStorage.js';
+import { getTargets, onChange } from './sharedStorage.js';
+import { aggregateRange, getSettings } from './data-layer.js';
 import { badgeLabel, formatNumber, minutesToHours, percent, statusFromRules } from './utils.js';
 
 const HERO_ID = 'hero-kpi';
@@ -114,8 +115,8 @@ export function initHeroKpi() {
     const currentCaption = container.querySelector('#hero-kpi-caption');
     const tz = resolveTimezone();
     const range = resolveRange(state.range, tz);
-    const totals = SharedStorage.aggregateRange(range.start, range.end);
-    const targets = SharedStorage.getTargets();
+    const totals = aggregateRange(range.start, range.end);
+    const targets = getTargets();
 
     const metricPayloads = METRICS.map((metric) => {
       const total = totals[metric.totalKey] || 0;
@@ -151,7 +152,7 @@ export function initHeroKpi() {
     const previousRange = resolvePreviousRange(range, tz);
     let deltaInfo = null;
     if (previousRange) {
-      const previousTotals = SharedStorage.aggregateRange(previousRange.start, previousRange.end);
+      const previousTotals = aggregateRange(previousRange.start, previousRange.end);
       const previousCompletions = METRICS.map((metric) => {
         const total = previousTotals[metric.totalKey] || 0;
         const dailyTarget = targets[metric.targetKey] || 0;
@@ -234,15 +235,11 @@ export function initHeroKpi() {
   updateFilters(state.range);
   render();
 
-  SharedStorage.onChange((payload) => {
-    if (!payload || ['logs', 'targets', 'settings'].includes(payload.target)) {
-      render();
-    }
-  });
+  onChange(render);
 }
 
 function resolveTimezone() {
-  const settings = SharedStorage.getSettings();
+  const settings = getSettings();
   return settings?.tz || 'Europe/Amsterdam';
 }
 

--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -68,16 +68,13 @@
 
   function highlightActive(container) {
     if (!container || typeof document === 'undefined') return;
-    const path = (window.location?.pathname || '').toLowerCase();
+    const file = (window.location?.pathname || '').split('/').pop().toLowerCase();
+    const route = (file || 'index.html').replace('.html', '');
+    const normalizedRoute = route === 'diaryplus' ? 'diary' : route;
     container.querySelectorAll('a[data-route]').forEach((link) => {
-      const route = link.dataset.route ? link.dataset.route.toLowerCase() : '';
-      const isActive = route && path.includes(route);
-      link.classList.toggle('is-active', Boolean(isActive));
-      if (isActive) {
-        link.setAttribute('aria-current', 'page');
-      } else {
-        link.removeAttribute('aria-current');
-      }
+      const isActive = (link.dataset.route || '').toLowerCase() === normalizedRoute;
+      link.classList.toggle('is-active', isActive);
+      link.toggleAttribute('aria-current', isActive);
     });
   }
 

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -1,4 +1,5 @@
-import { SharedStorage } from './sharedStorage.js';
+import { getTargets, onChange } from './sharedStorage.js';
+import { aggregateDay } from './data-layer.js';
 import { percent, formatNumber } from './utils.js';
 
 export function initInsights() {
@@ -26,19 +27,15 @@ export function initInsights() {
   }
 
   render();
-  SharedStorage.onChange((payload) => {
-    if (!payload || payload.target === 'logs' || payload.target === 'targets') {
-      render();
-    }
-  });
+  onChange(render);
 }
 
 function computeInsights() {
   const insights = [];
   const now = new Date();
   const hour = now.getHours();
-  const today = SharedStorage.aggregateDay(now);
-  const targets = SharedStorage.getTargets();
+  const today = aggregateDay(now);
+  const targets = getTargets();
 
   const waterTarget = targets.water_ml || 0;
   const waterPct = waterTarget ? percent(today.water_ml, waterTarget) : 0;

--- a/assets/js/sharedStorage.js
+++ b/assets/js/sharedStorage.js
@@ -1,541 +1,109 @@
-const STORAGE_KEY = 'health2099-db-v1';
-const CHANNEL_NAME = 'health2099';
-
-const DEFAULT_DB = {
-  version: 2,
-  logs: [],
-  targets: {
-    water_ml: 2000,
-    steps: 8000,
-    sleep_min: 420,
-    caffeine_mg: 300,
-  },
-  meds_today: [],
-  settings: {
-    tz: 'Europe/Amsterdam',
-    lastDevicePingISO: null,
-    batteryPct: 82,
-    city: '',
-  },
-  queue: [],
-};
-
+const KEY = 'health2099-db';
+let db = load();
 const listeners = new Set();
+const bc = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('health2099') : null;
 
-let db = safeLoad();
-persist();
-
-const channel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel(CHANNEL_NAME) : null;
-
-if (channel) {
-  channel.addEventListener('message', (event) => {
-    if (event?.data?.type === 'db-updated') {
-      db = safeLoad();
-      notify(event?.data?.payload || null);
-    }
-  });
-}
-
-export const getDB = () => clone(db);
-
-export function setDB(next, options = {}) {
-  const { payload = null, broadcast = true, skipNormalize = false } = options;
-  const prepared = skipNormalize ? next : prepareState(next || {});
-  db = prepared;
-  persist();
-  if (broadcast && channel) {
-    try {
-      channel.postMessage({ type: 'db-updated', payload });
-    } catch (error) {
-      console.warn('[sharedStorage] Failed to broadcast db update', error);
-    }
+function load() {
+  if (typeof localStorage === 'undefined') {
+    return def();
   }
-  notify(payload);
-  return getDB();
-}
-
-export function listLogs({ type, limit, since } = {}) {
-  let items = [...db.logs];
-  if (type) {
-    items = items.filter((log) => log.type === type);
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return def();
+    const parsed = JSON.parse(raw);
+    return sanitizeDB(parsed);
+  } catch (error) {
+    console.warn('[sharedStorage] Failed to load db, using defaults', error);
+    return def();
   }
-  if (since) {
-    const sinceDate = new Date(since);
-    items = items.filter((log) => new Date(log.createdAt) >= sinceDate);
-  }
-  if (typeof limit === 'number') {
-    items = items.slice(0, limit);
-  }
-  return items;
 }
 
-export function pushLog(type, value, options = {}) {
-  const log = createLog(type, value, options);
-  const nextLogs = [log, ...db.logs].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-  const nextSettings = { ...db.settings, lastDevicePingISO: log.createdAt };
-  write({ ...db, logs: nextLogs, settings: nextSettings }, { target: 'logs', action: 'push', log });
-  return log;
-}
-
-export function updateLog(id, updates) {
-  let updated = null;
-  const nextLogs = db.logs.map((log) => {
-    if (log.id !== id) return log;
-    updated = normalizeLog({ ...log, ...(updates || {}), updatedAt: new Date().toISOString() });
-    return updated;
-  });
-  if (updated) {
-    write({ ...db, logs: nextLogs }, { target: 'logs', action: 'update', log: updated });
-  }
-  return updated;
-}
-
-export function removeLog(id) {
-  const removed = db.logs.find((log) => log.id === id) || null;
-  if (!removed) return null;
-  const nextLogs = db.logs.filter((log) => log.id !== id);
-  write({ ...db, logs: nextLogs }, { target: 'logs', action: 'remove', log: removed });
-  return removed;
-}
-
-export function getTargets() {
-  return { ...db.targets };
-}
-
-export function setTargets(nextTargets) {
-  const targets = normalizeTargets({ ...db.targets, ...(nextTargets || {}) });
-  write({ ...db, targets }, { target: 'targets', action: 'set', targets: { ...targets } });
-  return getTargets();
-}
-
-export function getSettings() {
-  return { ...db.settings };
-}
-
-export function setSettings(partial) {
-  const settings = normalizeSettings({ ...db.settings, ...(partial || {}) });
-  write({ ...db, settings }, { target: 'settings', action: 'set', settings: { ...settings } });
-  return getSettings();
-}
-
-export function getMedsToday() {
-  return db.meds_today.map((med) => ({ ...med }));
-}
-
-export function setMedsToday(next) {
-  const meds = normalizeMeds(next);
-  write({ ...db, meds_today: meds }, { target: 'meds', action: 'set', meds: meds.map((item) => ({ ...item })) });
-  return getMedsToday();
-}
-
-export function updateMedToday(id, updates) {
-  let updated = null;
-  const meds = db.meds_today.map((med) => {
-    if (med.id !== id) return med;
-    updated = { ...med, ...(updates || {}) };
-    return updated;
-  });
-  if (updated) {
-    setMedsToday(meds);
-  }
-  return updated;
-}
-
-export function onChange(listener) {
-  if (typeof listener !== 'function') return () => {};
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
-
-export function addQueue(action) {
-  const item = {
-    id: createId('queue'),
-    createdAt: new Date().toISOString(),
-    ...(action || {}),
+function def() {
+  return {
+    logs: [],
+    targets: { water_ml: 2000, steps: 8000, sleep_min: 420, caffeine_mg: 300 },
+    meds_today: [],
+    settings: { tz: 'Europe/Amsterdam', lastDevicePingISO: null, batteryPct: null },
   };
-  const queue = [...db.queue, item];
-  write({ ...db, queue }, { target: 'queue', action: 'push', item });
-  return item;
 }
 
-export function flushQueue(flushFn) {
-  if (!db.queue.length) return Promise.resolve([]);
-  const items = [...db.queue];
-  write({ ...db, queue: [] }, { target: 'queue', action: 'flush' });
-  if (typeof flushFn === 'function') {
-    return Promise.resolve(flushFn(items));
-  }
-  return Promise.resolve(items);
-}
-
-export function removeQueue(predicate) {
-  if (typeof predicate !== 'function') return;
-  const queue = db.queue.filter((item) => !predicate(item));
-  write({ ...db, queue }, { target: 'queue', action: 'remove' });
-}
-
-export function recentLogs(hours = 24) {
-  const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
-  return listLogs({ since: cutoff.toISOString() });
-}
-
-export function aggregateDay(date = new Date()) {
-  const tz = getTimezone();
-  const start = startOfDay(date, tz);
-  const end = endOfDay(date, tz);
-  return aggregateRange(start, end);
-}
-
-export function aggregateRange(start, end) {
+function sanitizeDB(next) {
+  const base = def();
   const result = {
-    water_ml: 0,
-    steps: 0,
-    sleep_min: 0,
-    caffeine_mg: 0,
-    meds_taken: 0,
+    ...base,
+    ...(next && typeof next === 'object' ? next : {}),
   };
-  const startTime = start.getTime();
-  const endTime = end.getTime();
-  db.logs.forEach((log) => {
-    const time = new Date(log.createdAt).getTime();
-    if (time < startTime || time > endTime) return;
-    switch (log.type) {
-      case 'water':
-        result.water_ml += log.value || 0;
-        break;
-      case 'steps':
-        result.steps += log.value || 0;
-        break;
-      case 'sleep':
-        result.sleep_min += log.value || 0;
-        break;
-      case 'caffeine':
-        result.caffeine_mg += log.value || 0;
-        break;
-      case 'med':
-        result.meds_taken += 1;
-        break;
-      default:
-        break;
-    }
-  });
+  result.logs = Array.isArray(result.logs) ? result.logs.map(sanitizeLog).sort(sortLogs) : [];
+  result.targets = {
+    ...base.targets,
+    ...(result.targets && typeof result.targets === 'object' ? result.targets : {}),
+  };
+  result.meds_today = Array.isArray(result.meds_today)
+    ? result.meds_today.map((item) => ({ id: ensureId(item.id), title: item.title || '', taken: Boolean(item.taken) }))
+    : [];
+  result.settings = {
+    ...base.settings,
+    ...(result.settings && typeof result.settings === 'object' ? result.settings : {}),
+  };
   return result;
 }
 
-export function streaks(days = 14) {
-  const dayMap = new Map();
-  const tz = getTimezone();
-  for (let i = 0; i < days; i += 1) {
-    const reference = new Date(Date.now() - i * 86400000);
-    const day = startOfDay(reference, tz);
-    const key = day.toISOString();
-    dayMap.set(key, aggregateDay(day));
-  }
-  return dayMap;
+function sanitizeLog(log) {
+  if (!log || typeof log !== 'object') return createLog({});
+  return createLog(log);
 }
 
-export function startOfDayISO(date = new Date(), tz = getTimezone()) {
-  return startOfDay(date, tz).toISOString();
-}
-
-export function createLog(type, value, options = {}) {
-  const now = new Date();
-  const tzOffset = now.getTimezoneOffset();
-  const iso = new Date(now.getTime() - tzOffset * 60000).toISOString();
-  const log = normalizeLog({
-    id: options.id,
-    type,
-    value,
-    unit: options.unit,
-    note: options.note || '',
-    createdAt: options.createdAt || iso,
-    updatedAt: options.updatedAt || iso,
-    source: options.source,
-  });
-  return log;
-}
-
-function safeLoad() {
-  const stored = readStorage();
-  return prepareState(stored);
-}
-
-function readStorage() {
-  if (typeof localStorage === 'undefined') {
-    return {};
-  }
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : {};
-  } catch (error) {
-    console.warn('[sharedStorage] Failed to read db', error);
-    return {};
-  }
-}
-
-function prepareState(source) {
-  const migrated = migrateSchema(source || {});
-  const base = mergeDeep({}, DEFAULT_DB, migrated);
-  const next = {
-    ...base,
-    logs: Array.isArray(base.logs)
-      ? base.logs
-          .filter((item) => item && (item.id || item.createdAt))
-          .map(normalizeLog)
-          .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-      : [],
-    targets: normalizeTargets(base.targets),
-    meds_today: normalizeMeds(base.meds_today),
-    settings: normalizeSettings(base.settings),
-    queue: Array.isArray(base.queue) ? base.queue.filter(Boolean) : [],
-  };
-  return next;
-}
-
-function migrateSchema(source) {
-  const draft = { ...source };
-
-  if (draft.targets) {
-    if (typeof draft.targets.water === 'number') {
-      draft.targets.water_ml = draft.targets.water;
-    }
-    if (typeof draft.targets.sleep === 'number') {
-      draft.targets.sleep_min = draft.targets.sleep;
-    }
-    if (typeof draft.targets.caffeine === 'number') {
-      draft.targets.caffeine_mg = draft.targets.caffeine;
-    }
-  }
-
-  if (Array.isArray(draft.targets?.meds) && !Array.isArray(draft.meds_today)) {
-    draft.meds_today = draft.targets.meds.map((med) => ({
-      id: med.id || createId('med'),
-      title: med.name || med.title || 'Medication',
-      timeISO: med.timeISO || med.timeIso || null,
-      taken: Boolean(med.taken),
-    }));
-    delete draft.targets.meds;
-  }
-
-  if (draft.settings) {
-    if (draft.settings.deviceBattery != null && draft.settings.batteryPct == null) {
-      draft.settings.batteryPct = draft.settings.deviceBattery;
-    }
-    if (draft.settings.lastDevicePing && !draft.settings.lastDevicePingISO) {
-      draft.settings.lastDevicePingISO = draft.settings.lastDevicePing;
-    }
-  }
-
-  if (Array.isArray(draft.logs)) {
-    draft.logs = draft.logs.map((log) => {
-      if (log.type === 'meds') {
-        return { ...log, type: 'med' };
-      }
-      return log;
-    });
-  }
-
-  return draft;
-}
-
-function mergeDeep(target, ...sources) {
-  if (!sources.length) return target;
-  const source = sources.shift();
-  if (isObject(target) && isObject(source)) {
-    Object.keys(source).forEach((key) => {
-      if (isObject(source[key])) {
-        if (!target[key]) Object.assign(target, { [key]: {} });
-        mergeDeep(target[key], source[key]);
-      } else {
-        Object.assign(target, { [key]: source[key] });
-      }
-    });
-  }
-  return mergeDeep(target, ...sources);
-}
-
-function isObject(item) {
-  return item && typeof item === 'object' && !Array.isArray(item);
-}
-
-function normalizeLog(log) {
-  const now = new Date();
-  const created = new Date(log.createdAt || log.created_at || now);
-  const updated = new Date(log.updatedAt || log.updated_at || created);
-  const type = typeof log.type === 'string' ? log.type.toLowerCase() : 'generic';
+function createLog(log) {
+  const iso = toISO(log.createdAt || log.ts);
   return {
-    id: String(log.id || createId('log')),
-    type,
+    id: ensureId(log.id),
+    type: log.type || 'note',
     value: toNumber(log.value),
-    unit: log.unit || inferUnit(type),
-    note: log.note || '',
-    createdAt: created.toISOString(),
-    updatedAt: updated.toISOString(),
-    source: log.source || 'manual',
+    note: typeof log.note === 'string' ? log.note : '',
+    createdAt: iso,
+    updatedAt: toISO(log.updatedAt) || iso,
+    source: log.source || null,
   };
 }
 
-function normalizeTargets(targets) {
-  const next = { ...DEFAULT_DB.targets, ...(targets || {}) };
-  next.water_ml = ensureNumber(next.water_ml, DEFAULT_DB.targets.water_ml);
-  next.steps = ensureNumber(next.steps, DEFAULT_DB.targets.steps);
-  next.sleep_min = ensureNumber(next.sleep_min, DEFAULT_DB.targets.sleep_min);
-  next.caffeine_mg = ensureNumber(next.caffeine_mg, DEFAULT_DB.targets.caffeine_mg);
-  return next;
+function toISO(value) {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return new Date().toISOString();
+  }
+  return date.toISOString();
 }
 
-function normalizeMeds(meds) {
-  if (!Array.isArray(meds)) return [];
-  return meds
-    .map((med) => ({
-      id: med.id || createId('med'),
-      title: med.title || med.name || 'Medication',
-      timeISO: med.timeISO || med.timeIso || null,
-      taken: Boolean(med.taken),
-    }))
-    .filter((med) => med.id && med.title);
+function ensureId(id) {
+  if (id) return id;
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `log_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
 }
 
-function normalizeSettings(settings) {
-  const next = { ...DEFAULT_DB.settings, ...(settings || {}) };
-  if (next.batteryPct != null) {
-    const battery = Number(next.batteryPct);
-    next.batteryPct = Number.isFinite(battery) ? battery : null;
-  }
-  if (next.lastDevicePingISO) {
-    const ping = new Date(next.lastDevicePingISO);
-    next.lastDevicePingISO = Number.isNaN(ping.getTime()) ? null : ping.toISOString();
-  }
-  if (typeof next.city !== 'string') {
-    next.city = '';
-  } else {
-    next.city = next.city.trim();
-  }
-  if (typeof next.tz !== 'string' || !next.tz) {
-    next.tz = DEFAULT_DB.settings.tz;
-  }
-  return next;
-}
-
-function ensureNumber(value, fallback) {
-  const num = Number(value);
-  return Number.isFinite(num) ? num : fallback;
-}
-
-function inferUnit(type) {
-  switch (type) {
-    case 'water':
-      return 'ml';
-    case 'steps':
-      return 'steps';
-    case 'sleep':
-      return 'min';
-    case 'caffeine':
-      return 'mg';
-    case 'med':
-      return 'dose';
-    default:
-      return '';
-  }
+function sortLogs(a, b) {
+  const aTime = new Date(a.createdAt).getTime();
+  const bTime = new Date(b.createdAt).getTime();
+  return bTime - aTime;
 }
 
 function toNumber(value) {
-  if (value == null || value === '') return null;
+  if (value === '' || value == null) return null;
   const num = Number(value);
   return Number.isFinite(num) ? num : null;
-}
-
-function write(nextState, payload) {
-  setDB(nextState, { payload });
 }
 
 function persist(state = db) {
   if (typeof localStorage === 'undefined') return;
   try {
-    const snapshot = {
-      version: state.version,
-      logs: state.logs,
-      targets: state.targets,
-      meds_today: state.meds_today,
-      settings: state.settings,
-      queue: state.queue,
-    };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+    localStorage.setItem(KEY, JSON.stringify(state));
   } catch (error) {
     console.warn('[sharedStorage] Failed to persist db', error);
   }
-}
-
-function notify(payload) {
-  listeners.forEach((listener) => {
-    try {
-      listener(payload || null);
-    } catch (error) {
-      console.error('[sharedStorage] Listener error', error);
-    }
-  });
-}
-
-function getTimezone() {
-  const tz = (db && db.settings && db.settings.tz) || DEFAULT_DB.settings.tz;
-  if (tz) return tz;
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone;
-  } catch (error) {
-    return 'UTC';
-  }
-}
-
-function startOfDay(date, tz = getTimezone()) {
-  try {
-    const parts = zonedParts(date, tz);
-    return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 0, 0, 0, 0));
-  } catch (error) {
-    const d = new Date(date);
-    d.setHours(0, 0, 0, 0);
-    return d;
-  }
-}
-
-function endOfDay(date, tz = getTimezone()) {
-  try {
-    const parts = zonedParts(date, tz);
-    return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 23, 59, 59, 999));
-  } catch (error) {
-    const d = new Date(date);
-    d.setHours(23, 59, 59, 999);
-    return d;
-  }
-}
-
-function zonedParts(date, tz) {
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: tz,
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    hour12: false,
-  });
-  const parts = formatter.formatToParts(date);
-  const result = {
-    year: 1970,
-    month: 1,
-    day: 1,
-    hour: 0,
-    minute: 0,
-    second: 0,
-  };
-  parts.forEach((part) => {
-    if (part.type === 'literal') return;
-    const value = Number(part.value);
-    if (Number.isFinite(value)) {
-      result[part.type] = value;
-    }
-  });
-  return result;
 }
 
 function clone(value) {
@@ -545,35 +113,102 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function createId(prefix = 'id') {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID();
+export const getDB = () => clone(db);
+
+export function setDB(next) {
+  const nextState = sanitizeDB(next);
+  db = nextState;
+  persist(db);
+  if (bc) {
+    try {
+      bc.postMessage({ type: 'db-updated' });
+    } catch (error) {
+      console.warn('[sharedStorage] Failed to broadcast db update', error);
+    }
   }
-  return `${prefix}_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+  notify();
+  return getDB();
 }
 
-export const SharedStorage = {
-  getDB,
-  setDB,
-  listLogs,
-  pushLog,
-  updateLog,
-  removeLog,
-  recentLogs,
-  aggregateDay,
-  aggregateRange,
-  streaks,
-  getTargets,
-  setTargets,
-  getSettings,
-  setSettings,
-  getMedsToday,
-  setMedsToday,
-  updateMedToday,
-  onChange,
-  addQueue,
-  flushQueue,
-  removeQueue,
-  createLog,
-  startOfDayISO,
-};
+export function getTargets() {
+  return { ...db.targets };
+}
+
+export function setTargets(nextTargets) {
+  const merged = {
+    ...db.targets,
+    ...(nextTargets && typeof nextTargets === 'object' ? nextTargets : {}),
+  };
+  setDB({ ...db, targets: merged });
+  return { ...merged };
+}
+
+export function pushLog(payload) {
+  const item = createLog(payload || {});
+  setDB({ ...db, logs: [item, ...db.logs] });
+  return item;
+}
+
+export function updateLog(id, patch) {
+  if (!id) return null;
+  let updated = null;
+  const nextLogs = db.logs.map((log) => {
+    if (log.id !== id) return log;
+    updated = createLog({ ...log, ...(patch || {}), id: log.id, updatedAt: new Date().toISOString() });
+    return updated;
+  });
+  if (updated) {
+    setDB({ ...db, logs: nextLogs });
+  }
+  return updated;
+}
+
+export function removeLog(id) {
+  if (!id) return null;
+  const existing = db.logs.find((log) => log.id === id) || null;
+  if (!existing) return null;
+  setDB({ ...db, logs: db.logs.filter((log) => log.id !== id) });
+  return existing;
+}
+
+export function listLogs(options = {}) {
+  const { type, since, until } = options || {};
+  const sinceTime = since ? new Date(since).getTime() : null;
+  const untilTime = until ? new Date(until).getTime() : null;
+  return db.logs.filter((log) => {
+    if (type && log.type !== type) return false;
+    const time = new Date(log.createdAt).getTime();
+    if (Number.isNaN(time)) return false;
+    if (sinceTime != null && time < sinceTime) return false;
+    if (untilTime != null && time > untilTime) return false;
+    return true;
+  });
+}
+
+export function onChange(fn) {
+  if (typeof fn !== 'function') {
+    return () => {};
+  }
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+function notify() {
+  const snapshot = getDB();
+  listeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      console.error('[sharedStorage] Listener error', error);
+    }
+  });
+}
+
+if (bc) {
+  bc.addEventListener('message', (event) => {
+    if (event?.data?.type === 'db-updated') {
+      db = load();
+      notify();
+    }
+  });
+}

--- a/assets/js/streaks.js
+++ b/assets/js/streaks.js
@@ -1,4 +1,5 @@
-import { SharedStorage } from './sharedStorage.js';
+import { getTargets, onChange } from './sharedStorage.js';
+import { streaks } from './data-layer.js';
 import { minutesToHours, formatNumber } from './utils.js';
 
 let lastStreaks = { water_ml: 0, steps: 0, sleep_min: 0 };
@@ -9,8 +10,8 @@ export function initStreaks() {
   if (!list || !badgeContainer) return;
 
   function render() {
-    const targets = SharedStorage.getTargets();
-    const streakMap = SharedStorage.streaks(14);
+    const targets = getTargets();
+    const streakMap = streaks(14);
     const entries = Array.from(streakMap.entries());
     const metrics = [
       {
@@ -72,11 +73,7 @@ export function initStreaks() {
   }
 
   render();
-  SharedStorage.onChange((payload) => {
-    if (!payload || payload.target === 'logs' || payload.target === 'targets') {
-      render();
-    }
-  });
+  onChange(render);
 }
 
 function computeStreak(entries, metric, target) {

--- a/assets/js/summary-header.js
+++ b/assets/js/summary-header.js
@@ -1,4 +1,5 @@
-import { SharedStorage } from './sharedStorage.js';
+import { onChange } from './sharedStorage.js';
+import { getSettings } from './data-layer.js';
 import { formatDateRange } from './utils.js';
 
 const HEADER_ID = 'summary-header';
@@ -54,7 +55,7 @@ export function initHeader() {
 
   function render() {
     ensureStructure();
-    const settings = SharedStorage.getSettings();
+    const settings = getSettings();
     const now = new Date();
     const dateLabel = formatDateRange(now);
     const city = settings.city ? ` · ${settings.city}` : '';
@@ -78,11 +79,7 @@ export function initHeader() {
   }
 
   render();
-  SharedStorage.onChange((payload) => {
-    if (!payload || payload.target === 'logs' || payload.target === 'settings') {
-      render();
-    }
-  });
+  onChange(render);
 }
 
 function computeDeviceStatus(lastPing) {

--- a/assets/js/summary-page.js
+++ b/assets/js/summary-page.js
@@ -1,13 +1,11 @@
-import * as store from './sharedStorage.js';
+import './sharedStorage.js';
 import './summary-header.js';
 import './sidebar.js';
-import './quick-actions.js';
 import './hero-kpi.js';
-import './kpi.js';
+import './quick-actions.js';
 import './timeline.js';
 import './insights.js';
 import './streaks.js';
-import './kpi-rings.js';
 import './dev-seed.js';
 
 function ready(callback) {
@@ -19,8 +17,10 @@ function ready(callback) {
   }
 }
 
-ready(() => {
+ready(async () => {
   if (typeof window === 'undefined') return;
+  await import('./includes.js');
+  const module = await import('./sharedStorage.js');
   window.Health2099 = window.Health2099 || {};
-  window.Health2099.store = store.SharedStorage || store;
+  window.Health2099.store = module;
 });

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -1,4 +1,5 @@
-import { SharedStorage } from './sharedStorage.js';
+import { listLogs, pushLog, updateLog, onChange } from './sharedStorage.js';
+import { startOfDayISO } from './data-layer.js';
 import { iconForType, formatTime, isoToDate, unitLabel, formatNumber, pluralize } from './utils.js';
 
 const TIMELINE_LIST_ID = 'timeline-list';
@@ -22,11 +23,7 @@ export function initTimeline() {
   setupFilters(filtersHost, () => render(list, headerCount, heading));
   render(list, headerCount, heading);
 
-  SharedStorage.onChange((payload) => {
-    if (!payload || payload.target === 'logs' || payload.target === 'queue') {
-      render(list, headerCount, heading);
-    }
-  });
+  onChange(() => render(list, headerCount, heading));
 }
 
 function render(list, headerCount, heading) {
@@ -68,12 +65,12 @@ function updateFilterState(container) {
 
 function getLogsForRange(range) {
   const now = new Date();
-  let since = SharedStorage.startOfDayISO(now);
+  let since = startOfDayISO(now);
   if (range.days > 1) {
     const sinceDate = new Date(now.getTime() - (range.days - 1) * 86400000);
-    since = SharedStorage.startOfDayISO(sinceDate);
+    since = startOfDayISO(sinceDate);
   }
-  return SharedStorage.listLogs({ since });
+  return listLogs({ since });
 }
 
 function renderTimeline(list, logs, range) {
@@ -85,7 +82,7 @@ function renderTimeline(list, logs, range) {
     list.appendChild(empty);
     const button = document.getElementById('timeline-empty-add');
     if (button) {
-      button.addEventListener('click', () => SharedStorage.pushLog('water', 250));
+      button.addEventListener('click', () => pushLog({ type: 'water', value: 250 }));
     }
     return;
   }
@@ -199,7 +196,7 @@ function startInlineEdit(element, field, log, container) {
         updateFieldDisplay(element, log, field);
         return;
       }
-      const updated = SharedStorage.updateLog(log.id, updates) || { ...log, ...updates };
+      const updated = updateLog(log.id, updates) || { ...log, ...updates };
       Object.assign(log, updated);
       element.dataset.editing = 'false';
       element.innerHTML = '';

--- a/partials/sidenav.html
+++ b/partials/sidenav.html
@@ -6,7 +6,7 @@
     <span aria-hidden="true">📈</span>
     <span>Summary</span>
   </a>
-  <a class="nav-link" data-route="health" href="HealthCabinet.html">
+  <a class="nav-link" data-route="healthcabinet" href="HealthCabinet.html">
     <span aria-hidden="true">🧬</span>
     <span>Health cabinet</span>
   </a>


### PR DESCRIPTION
## Summary
- rebuild the shared storage module around the new public API and broadcast handling
- add a data-layer helper and migrate summary modules to the simplified storage API with a single module entry point
- align Summary styling and navigation with compact hero spacing, consistent CSS, and corrected active link logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e74d52b6a4833292b1965f4563386a