### PR TITLE
Move quick actions to sidebar with offline quick log

### DIFF
--- a/Diary.html
+++ b/Diary.html
@@ -326,10 +326,8 @@
           }
 
           const addButton = form.querySelector('button[type="submit"]');
-          const valueInput = form.elements.value;
-          const target = options.action === 'add' ? addButton : valueInput;
-          if (target && typeof target.focus === 'function') {
-            target.focus();
+          if (addButton && typeof addButton.focus === 'function') {
+            requestAnimationFrame(() => addButton.focus());
           }
           form.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }

--- a/Summary.html
+++ b/Summary.html
@@ -10,7 +10,8 @@
     <link rel="stylesheet" href="./shared/styles.css" />
     <link rel="stylesheet" href="./assets/css/summary.css?v=20240716" />
     <link rel="stylesheet" href="./assets/css/morning.css?v=20240716" />
-    <link rel="stylesheet" href="./assets/css/quick-actions.css?v=20240716" />
+    <link rel="stylesheet" href="./assets/css/quick-log.css?v=20240716" />
+    <link rel="stylesheet" href="./assets/css/goals.css?v=20240716" />
     <link rel="stylesheet" href="./assets/css/animations.css?v=20240716" />
     <link rel="stylesheet" href="./assets/css/timeline.css?v=20240716" />
     <link rel="stylesheet" href="./assets/css/ui.css?v=20240716" />
@@ -153,13 +154,6 @@
               <section aria-labelledby="kpi-heading" class="kpi-grid" id="kpi-grid" role="region" data-kpi-rings>
                 <h2 id="kpi-heading" class="visually-hidden">Key wellness metrics</h2>
               </section>
-              <section class="quick-actions" aria-labelledby="actions-heading" role="region">
-                <header>
-                  <h2 id="actions-heading">Quick actions</h2>
-                  <p>Log habits in a tap. Offline entries queue automatically.</p>
-                </header>
-                <div class="quick-actions__sections" id="quick-actions" role="group" aria-label="Quick log actions"></div>
-              </section>
               <section class="timeline" aria-labelledby="timeline-heading" role="region">
                 <header class="timeline__header">
                   <div class="timeline__title">
@@ -188,40 +182,42 @@
           </div>
           <aside class="summary-sidebar" aria-labelledby="sidebar-heading">
             <h2 id="sidebar-heading" class="visually-hidden">Sidebar</h2>
-            <section class="sidebar-section diary-links" aria-labelledby="diary-links-heading">
-              <header>
-                <h3 id="diary-links-heading">Diary shortcuts</h3>
+            <section
+              class="sidebar-section sidebar-section--quick-log"
+              aria-labelledby="quick-log-heading"
+            >
+              <header class="quick-log__header">
+                <div class="quick-log__title">
+                  <h3 id="quick-log-heading">Quick actions</h3>
+                  <p>Log habits in a tap. Offline entries queue automatically.</p>
+                </div>
+                <button
+                  type="button"
+                  class="quick-log__edit card-press"
+                  id="edit-goals"
+                  aria-haspopup="dialog"
+                >
+                  Edit goals
+                </button>
               </header>
-              <div class="diary-links__grid" id="diary-links" role="group" aria-label="Diary quick links">
-                <a class="diary-link card-press card-hover" data-section="meds" href="Diary.html?section=meds&amp;date=today">
-                  <span class="diary-link__title">Meds today</span>
-                  <span class="diary-link__hint">Review and adjust doses</span>
+              <div class="quick-log" id="quick-log" role="group" aria-label="Quick actions"></div>
+              <div class="quick-log__links" id="quick-log-links" role="group" aria-label="Diary shortcuts">
+                <a
+                  class="quick-log__link card-press card-hover"
+                  data-section="meds"
+                  href="Diary.html?section=meds&amp;date=today"
+                >
+                  <span class="quick-log__link-title">Meds today</span>
+                  <span class="quick-log__link-hint">Review and adjust doses</span>
                 </a>
-                <a class="diary-link card-press card-hover" data-section="food" href="Diary.html?section=food&amp;date=today&amp;action=add">
-                  <span class="diary-link__title">Meals</span>
-                  <span class="diary-link__hint">Log a meal or snack</span>
+                <a
+                  class="quick-log__link card-press card-hover"
+                  data-section="food"
+                  href="Diary.html?section=food&amp;date=today&amp;action=add"
+                >
+                  <span class="quick-log__link-title">Meals</span>
+                  <span class="quick-log__link-hint">Log a meal or snack</span>
                 </a>
-              </div>
-            </section>
-            <section class="sidebar-section" aria-labelledby="targets-heading">
-              <header>
-                <h3 id="targets-heading">Targets</h3>
-              </header>
-              <div class="target-item">
-                <label for="target-water">Water goal (ml)</label>
-                <input id="target-water" type="number" inputmode="numeric" min="0" />
-              </div>
-              <div class="target-item">
-                <label for="target-steps">Steps goal</label>
-                <input id="target-steps" type="number" inputmode="numeric" min="0" />
-              </div>
-              <div class="target-item">
-                <label for="target-sleep">Sleep goal (minutes)</label>
-                <input id="target-sleep" type="number" inputmode="numeric" min="0" />
-              </div>
-              <div class="target-item">
-                <label for="target-caffeine">Caffeine ceiling (mg)</label>
-                <input id="target-caffeine" type="number" inputmode="numeric" min="0" />
               </div>
             </section>
             <section class="sidebar-section" aria-labelledby="meds-heading">

--- a/assets/css/goals.css
+++ b/assets/css/goals.css
@@ -1,0 +1,171 @@
+.goals-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  opacity: 0;
+}
+
+.goals-sheet[data-state='open'] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+body.goals-open {
+  overflow: hidden;
+}
+
+.goals-sheet__backdrop {
+  grid-area: 1 / 1;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.goals-sheet__panel {
+  grid-area: 1 / 1;
+  align-self: end;
+  width: min(560px, 100%);
+  margin: 0 auto;
+  background: var(--surface, #fff);
+  border-radius: 24px 24px 0 0;
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.24);
+  padding: clamp(1rem, 2vw, 1.5rem);
+  display: grid;
+  gap: 1rem;
+  max-height: calc(100% - 3rem);
+  overflow-y: auto;
+}
+
+.goals-sheet__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.goals-sheet__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.goals-sheet__close {
+  font-size: 1.5rem;
+  line-height: 1;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+}
+
+.goals-sheet__status {
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-success, #16a34a);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.goals-sheet__status.is-visible {
+  opacity: 1;
+}
+
+.goals-sheet__content {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.goals-sheet__section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.goals-sheet__section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.goals-sheet__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.goals-sheet__chip {
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.goals-sheet__chip--custom {
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 0.5rem 0.75rem;
+}
+
+.goals-sheet__chip.is-active {
+  background: rgba(37, 99, 235, 0.18);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.goals-sheet__chip:focus-visible {
+  outline: 3px solid var(--color-focus, rgba(37, 99, 235, 0.65));
+  outline-offset: 2px;
+}
+
+.goals-sheet__custom {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.05);
+}
+
+.goals-sheet__custom-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.goals-sheet__custom input {
+  flex: 1;
+  min-width: 0;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  padding: 0.45rem 0.75rem;
+  font-size: 1rem;
+}
+
+.goals-sheet__custom input:focus-visible {
+  outline: 3px solid var(--color-focus, rgba(37, 99, 235, 0.65));
+  outline-offset: 2px;
+}
+
+.goals-sheet__custom button {
+  border-radius: 0.75rem;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+}
+
+@media (max-width: 540px) {
+  .goals-sheet__panel {
+    border-radius: 20px 20px 0 0;
+    width: 100%;
+  }
+
+  .goals-sheet__chips {
+    gap: 0.4rem;
+  }
+
+  .goals-sheet__chip {
+    flex: 1 1 calc(33% - 0.4rem);
+    text-align: center;
+  }
+}

--- a/assets/css/quick-log.css
+++ b/assets/css/quick-log.css
@@ -1,0 +1,225 @@
+.sidebar-section--quick-log {
+  display: grid;
+  gap: clamp(1rem, 1.5vw, 1.5rem);
+}
+
+.quick-log__header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.quick-log__title {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.quick-log__title h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text, var(--color-heading));
+}
+
+.quick-log__title p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted, var(--color-muted));
+}
+
+.quick-log__edit {
+  align-self: flex-start;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  color: var(--color-primary, #2563eb);
+  border: 1px solid currentColor;
+  background: transparent;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.quick-log__edit:focus-visible {
+  outline: 3px solid var(--color-focus, rgba(37, 99, 235, 0.65));
+  outline-offset: 2px;
+}
+
+.quick-log {
+  display: grid;
+  gap: clamp(1rem, 1.5vw, 1.25rem);
+}
+
+.quick-log__section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.quick-log__section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 0.75rem;
+  flex-wrap: wrap;
+}
+
+.quick-log__section-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text, var(--color-heading));
+}
+
+.quick-log__summary {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted, var(--color-muted));
+}
+
+.quick-log__pills {
+  display: grid;
+  gap: 0.5rem 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+}
+
+.quick-log__pill {
+  min-height: 48px;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--text, var(--color-heading));
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.quick-log__pill:hover {
+  background: rgba(37, 99, 235, 0.14);
+  border-color: rgba(37, 99, 235, 0.32);
+}
+
+.quick-log__pill:active {
+  transform: translateY(1px);
+}
+
+.quick-log__pill:focus-visible {
+  outline: 3px solid var(--color-focus, rgba(37, 99, 235, 0.65));
+  outline-offset: 2px;
+}
+
+.quick-log__pill--secondary {
+  background: rgba(15, 23, 42, 0.06);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.quick-log__pill-label {
+  display: block;
+  font-weight: 600;
+}
+
+.quick-log__pill-hint {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--muted, var(--color-muted));
+}
+
+.quick-log__secondary {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.quick-log__secondary .quick-log__pill {
+  width: 100%;
+  min-height: 56px;
+  padding: 0.75rem 1rem;
+  flex-direction: column;
+  text-align: center;
+}
+
+.quick-log__links {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.quick-log__link {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: inherit;
+  text-decoration: none;
+  min-height: 112px;
+}
+
+.quick-log__link-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.quick-log__link-hint {
+  font-size: 0.85rem;
+  color: var(--muted, var(--color-muted));
+}
+
+.quick-log__link:focus-visible {
+  outline: 3px solid var(--color-focus, rgba(37, 99, 235, 0.65));
+  outline-offset: 2px;
+}
+
+.quick-log__link:hover {
+  border-color: rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+@media (max-width: 720px) {
+  .quick-log__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .quick-log__edit {
+    align-self: flex-start;
+  }
+
+  .quick-log__section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .quick-log__summary {
+    font-size: 0.8rem;
+  }
+
+  .quick-log__pills {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .quick-log__pill {
+    min-height: 52px;
+    font-size: 1rem;
+  }
+
+  .quick-log__links {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .quick-log__pill {
+    min-height: 56px;
+  }
+
+  .quick-log__secondary .quick-log__pill {
+    min-height: 60px;
+  }
+}

--- a/assets/js/diary-link.js
+++ b/assets/js/diary-link.js
@@ -15,7 +15,7 @@ function withBase(path) {
 }
 
 function setupSummaryLinks() {
-  const links = document.querySelectorAll('.diary-link[href]');
+  const links = document.querySelectorAll('.diary-link[href], .quick-log__link[href]');
   links.forEach((link) => {
     const href = link.getAttribute('href');
     if (!href) return;

--- a/assets/js/goals-sheet.js
+++ b/assets/js/goals-sheet.js
@@ -1,0 +1,282 @@
+import { getTargets, setTargets, onChange } from './sharedStorage.js';
+
+const CONFIG = [
+  {
+    key: 'water_ml',
+    label: 'Water goal',
+    unit: 'ml',
+    presets: [1500, 2000, 2500],
+  },
+  {
+    key: 'steps',
+    label: 'Steps goal',
+    unit: 'steps',
+    presets: [6000, 8000, 10000],
+  },
+  {
+    key: 'caffeine_mg',
+    label: 'Caffeine ceiling',
+    unit: 'mg',
+    presets: [200, 300, 400],
+  },
+];
+
+let sheet = null;
+let statusEl = null;
+let initialized = false;
+let detach = null;
+const chipRefs = new Map();
+const customRefs = new Map();
+let statusTimer = null;
+
+export function initGoalsSheet() {
+  if (initialized) return;
+  sheet = createSheet();
+  document.body.appendChild(sheet);
+  updateTargets(getTargets());
+  detach = onChange((db) => updateTargets(db?.targets || getTargets()));
+  initialized = true;
+}
+
+export function openGoalsSheet() {
+  if (!initialized) {
+    initGoalsSheet();
+  }
+  if (!sheet) return;
+  sheet.dataset.state = 'open';
+  sheet.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('goals-open');
+  const focusTarget = sheet.querySelector('[data-focus-default]');
+  if (focusTarget) {
+    focusTarget.focus();
+  }
+}
+
+function closeGoalsSheet() {
+  if (!sheet) return;
+  sheet.dataset.state = 'closed';
+  sheet.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('goals-open');
+}
+
+function createSheet() {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'goals-sheet';
+  wrapper.id = 'goals-sheet';
+  wrapper.dataset.state = 'closed';
+  wrapper.setAttribute('aria-hidden', 'true');
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'goals-sheet__backdrop';
+  backdrop.dataset.action = 'close';
+  wrapper.appendChild(backdrop);
+
+  const panel = document.createElement('div');
+  panel.className = 'goals-sheet__panel';
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.setAttribute('aria-labelledby', 'goals-sheet-title');
+  wrapper.appendChild(panel);
+
+  const header = document.createElement('header');
+  header.className = 'goals-sheet__header';
+  panel.appendChild(header);
+
+  const title = document.createElement('h2');
+  title.id = 'goals-sheet-title';
+  title.textContent = 'Edit goals';
+  header.appendChild(title);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'goals-sheet__close card-press';
+  closeBtn.dataset.action = 'close';
+  closeBtn.setAttribute('aria-label', 'Close goals');
+  closeBtn.innerHTML = '&times;';
+  header.appendChild(closeBtn);
+
+  statusEl = document.createElement('div');
+  statusEl.className = 'goals-sheet__status';
+  statusEl.setAttribute('role', 'status');
+  statusEl.setAttribute('aria-live', 'polite');
+  panel.appendChild(statusEl);
+
+  const content = document.createElement('div');
+  content.className = 'goals-sheet__content';
+  panel.appendChild(content);
+
+  CONFIG.forEach((config, index) => {
+    const section = document.createElement('section');
+    section.className = 'goals-sheet__section';
+    section.dataset.targetKey = config.key;
+
+    const sectionTitle = document.createElement('h3');
+    sectionTitle.textContent = config.label;
+    section.appendChild(sectionTitle);
+
+    const chipGroup = document.createElement('div');
+    chipGroup.className = 'goals-sheet__chips';
+    chipGroup.setAttribute('role', 'group');
+    chipGroup.setAttribute('aria-label', `${config.label} presets`);
+
+    const valueMap = new Map();
+    config.presets.forEach((presetValue, idx) => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'goals-sheet__chip card-press';
+      chip.dataset.value = String(presetValue);
+      chip.setAttribute('aria-pressed', 'false');
+      if (index === 0 && idx === 0) {
+        chip.dataset.focusDefault = 'true';
+      }
+      chip.textContent = `${presetValue.toLocaleString()} ${config.unit}`;
+      chip.addEventListener('click', () => {
+        applyGoal(config.key, presetValue);
+      });
+      chipGroup.appendChild(chip);
+      valueMap.set(presetValue, chip);
+    });
+
+    const customChip = document.createElement('button');
+    customChip.type = 'button';
+    customChip.className = 'goals-sheet__chip goals-sheet__chip--custom card-press';
+    customChip.dataset.action = 'custom';
+    customChip.setAttribute('aria-pressed', 'false');
+    customChip.innerHTML = '&hellip;';
+    customChip.addEventListener('click', () => toggleCustom(section, true));
+    chipGroup.appendChild(customChip);
+    valueMap.set('custom', customChip);
+
+    chipRefs.set(config.key, valueMap);
+
+    section.appendChild(chipGroup);
+
+    const custom = document.createElement('form');
+    custom.className = 'goals-sheet__custom';
+    custom.dataset.customFor = config.key;
+    custom.hidden = true;
+
+    const label = document.createElement('label');
+    label.className = 'visually-hidden';
+    const inputId = `goal-custom-${config.key}`;
+    label.setAttribute('for', inputId);
+    label.textContent = `Custom ${config.label}`;
+    custom.appendChild(label);
+
+    const row = document.createElement('div');
+    row.className = 'goals-sheet__custom-row';
+    custom.appendChild(row);
+
+    const input = document.createElement('input');
+    input.id = inputId;
+    input.type = 'number';
+    input.min = '0';
+    input.inputMode = 'numeric';
+    input.placeholder = `e.g. ${config.presets[config.presets.length - 1] + 100}`;
+    row.appendChild(input);
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'submit';
+    saveBtn.className = 'card-press';
+    saveBtn.textContent = 'Save';
+    row.appendChild(saveBtn);
+
+    custom.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const numeric = Number(input.value);
+      if (!Number.isFinite(numeric) || numeric <= 0) return;
+      applyGoal(config.key, Math.round(numeric));
+      toggleCustom(section, false);
+    });
+
+    customRefs.set(config.key, { container: custom, input, toggle: (visible) => toggleCustom(section, visible) });
+    section.appendChild(custom);
+
+    content.appendChild(section);
+  });
+
+  wrapper.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (target.dataset.action === 'close') {
+      event.preventDefault();
+      closeGoalsSheet();
+    }
+  });
+
+  wrapper.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeGoalsSheet();
+    }
+  });
+
+  return wrapper;
+}
+
+function toggleCustom(section, visible) {
+  const custom = section.querySelector('.goals-sheet__custom');
+  const input = custom?.querySelector('input');
+  if (!custom) return;
+  custom.hidden = !visible;
+  if (visible && input) {
+    requestAnimationFrame(() => input.focus());
+  }
+}
+
+function applyGoal(key, value) {
+  const numeric = Math.max(0, Math.round(value || 0));
+  setTargets({ [key]: numeric });
+  announceSaved();
+  const current = getTargets();
+  updateTargets(current);
+}
+
+function updateTargets(targets) {
+  CONFIG.forEach((config) => {
+    const value = Number(targets?.[config.key]) || 0;
+    const chips = chipRefs.get(config.key);
+    const presets = new Set(config.presets);
+    if (chips) {
+      chips.forEach((chip, key) => {
+        const isCustom = key === 'custom';
+        const active = isCustom ? !presets.has(value) && value > 0 : Number(key) === value;
+        chip.classList.toggle('is-active', active);
+        chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    }
+    const custom = customRefs.get(config.key);
+    if (custom?.input) {
+      custom.input.value = value > 0 ? String(value) : '';
+    }
+    if (custom?.container) {
+      const shouldShow = value > 0 && !presets.has(value);
+      custom.container.hidden = !shouldShow;
+    }
+  });
+}
+
+function announceSaved() {
+  if (!statusEl) return;
+  statusEl.textContent = 'Saved';
+  statusEl.classList.add('is-visible');
+  clearTimeout(statusTimer);
+  statusTimer = setTimeout(() => {
+    statusEl.textContent = '';
+    statusEl.classList.remove('is-visible');
+  }, 2000);
+}
+
+export function destroyGoalsSheet() {
+  if (typeof detach === 'function') {
+    detach();
+    detach = null;
+  }
+  if (sheet?.parentElement) {
+    sheet.parentElement.removeChild(sheet);
+  }
+  sheet = null;
+  initialized = false;
+  chipRefs.clear();
+  customRefs.clear();
+}

--- a/assets/js/metrics.js
+++ b/assets/js/metrics.js
@@ -1,0 +1,106 @@
+import { getDB } from './sharedStorage.js';
+
+const TIME_ZONE = 'Europe/Amsterdam';
+
+const dateFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: TIME_ZONE,
+  hour12: false,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+});
+
+const weekdayFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: TIME_ZONE,
+  weekday: 'short',
+});
+
+const WEEKDAY_INDEX = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+export function sumToday(type, db) {
+  const snapshot = db || getDB();
+  return sumRange(type, startOfDay(new Date()), endOfDay(new Date()), snapshot);
+}
+
+export function sumWeek(type, db) {
+  const snapshot = db || getDB();
+  return sumRange(type, startOfWeek(new Date()), endOfWeek(new Date()), snapshot);
+}
+
+export function sumRange(type, start, end, db = getDB()) {
+  if (!type) return 0;
+  const logs = Array.isArray(db?.logs) ? db.logs : [];
+  const startTime = start?.getTime?.() ?? Number.NEGATIVE_INFINITY;
+  const endTime = end?.getTime?.() ?? Number.POSITIVE_INFINITY;
+  return logs.reduce((total, log) => {
+    if (!log || log.type !== type) return total;
+    const value = Number(log.value);
+    if (!Number.isFinite(value)) return total;
+    const time = new Date(log.createdAt).getTime();
+    if (Number.isNaN(time)) return total;
+    if (time < startTime || time >= endTime) return total;
+    return total + value;
+  }, 0);
+}
+
+function startOfDay(date) {
+  const parts = toZonedParts(date);
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 0, 0, 0, 0));
+}
+
+function endOfDay(date) {
+  const start = startOfDay(date);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+  return end;
+}
+
+function startOfWeek(date) {
+  const start = startOfDay(date);
+  const weekday = getWeekdayIndex(date);
+  const diff = (weekday + 6) % 7;
+  const weekStart = new Date(start);
+  weekStart.setUTCDate(weekStart.getUTCDate() - diff);
+  return weekStart;
+}
+
+function endOfWeek(date) {
+  const start = startOfWeek(date);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 7);
+  return end;
+}
+
+function toZonedParts(date) {
+  const parts = dateFormatter.formatToParts(date || new Date());
+  const lookup = Object.create(null);
+  parts.forEach((part) => {
+    if (part.type === 'literal') return;
+    lookup[part.type] = part.value;
+  });
+  return {
+    year: Number(lookup.year),
+    month: Number(lookup.month),
+    day: Number(lookup.day),
+    hour: Number(lookup.hour),
+    minute: Number(lookup.minute),
+    second: Number(lookup.second),
+  };
+}
+
+function getWeekdayIndex(date) {
+  const label = weekdayFormatter.format(date || new Date());
+  const index = WEEKDAY_INDEX[label];
+  return typeof index === 'number' ? index : 0;
+}

--- a/assets/js/offline-queue.js
+++ b/assets/js/offline-queue.js
@@ -1,0 +1,158 @@
+import { pushLog } from './sharedStorage.js';
+
+const STORAGE_KEY = 'health2099-offline-queue';
+
+let queue = loadQueue();
+const listeners = new Set();
+const flushListeners = new Set();
+
+export function getQueue() {
+  return queue.map((item) => ({ ...item }));
+}
+
+export function enqueue(entry) {
+  const item = normalizeEntry(entry);
+  queue = [...queue, item];
+  persist();
+  notify();
+  flushQueue();
+  return { ...item };
+}
+
+export function remove(id) {
+  const before = queue.length;
+  queue = queue.filter((item) => item.id !== id);
+  if (queue.length !== before) {
+    persist();
+    notify();
+  }
+}
+
+export function clearQueue() {
+  if (!queue.length) return;
+  queue = [];
+  persist();
+  notify();
+}
+
+export function onQueueChange(fn) {
+  if (typeof fn !== 'function') return () => {};
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export function onFlush(fn) {
+  if (typeof fn !== 'function') return () => {};
+  flushListeners.add(fn);
+  return () => flushListeners.delete(fn);
+}
+
+export function flushQueue() {
+  if (!queue.length) return;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return;
+  }
+  const pending = queue;
+  queue = [];
+  persist();
+  notify();
+  const failed = [];
+  pending.forEach((item) => {
+    try {
+      const log = pushLog({
+        type: item.type,
+        value: item.value,
+        unit: item.unit ?? null,
+        note: item.note ?? null,
+        source: item.source || 'quick',
+        meta: item.meta || null,
+      });
+      flushListeners.forEach((listener) => {
+        try {
+          listener({ entry: { ...item }, log });
+        } catch (error) {
+          console.error('[offline-queue] flush listener failed', error);
+        }
+      });
+    } catch (error) {
+      console.warn('[offline-queue] failed to flush entry, re-queueing', error);
+      failed.push(item);
+    }
+  });
+  if (failed.length) {
+    queue = [...failed, ...queue];
+    persist();
+    notify();
+  }
+}
+
+function normalizeEntry(entry) {
+  const now = new Date().toISOString();
+  return {
+    id: ensureId(entry?.id),
+    type: entry?.type || 'note',
+    value: Number(entry?.value ?? 0) || 0,
+    unit: entry?.unit ?? null,
+    note: typeof entry?.note === 'string' ? entry.note : null,
+    source: entry?.source || 'quick',
+    meta: entry?.meta && typeof entry.meta === 'object' ? { ...entry.meta } : null,
+    queuedAt: entry?.queuedAt || now,
+  };
+}
+
+function ensureId(id) {
+  if (id) return id;
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `queue_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+function loadQueue() {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item) => {
+        try {
+          return normalizeEntry(item);
+        } catch (error) {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch (error) {
+    console.warn('[offline-queue] failed to load queue', error);
+    return [];
+  }
+}
+
+function persist() {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+  } catch (error) {
+    console.warn('[offline-queue] failed to persist queue', error);
+  }
+}
+
+function notify() {
+  const snapshot = getQueue();
+  listeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      console.error('[offline-queue] listener error', error);
+    }
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', () => flushQueue());
+}
+
+// attempt initial flush when module loads
+flushQueue();

--- a/assets/js/quick-log.js
+++ b/assets/js/quick-log.js
@@ -1,0 +1,336 @@
+import { pushLog, removeLog, getTargets, onChange, getDB } from './sharedStorage.js';
+import { showToast } from './ui.js';
+import { sumToday, sumWeek } from './metrics.js';
+import {
+  enqueue as enqueueOffline,
+  remove as removeOffline,
+  getQueue,
+  onQueueChange,
+  onFlush,
+} from './offline-queue.js';
+import { openGoalsSheet, initGoalsSheet } from './goals-sheet.js';
+
+const TOAST_DURATION = 10000;
+
+const PRESETS = {
+  water: [200, 300, 500],
+  steps: [500, 1000, 2000],
+  caffeine: [50, 100],
+};
+
+const GROUPS = [
+  {
+    id: 'water',
+    label: 'Water',
+    unit: 'ml',
+    targetKey: 'water_ml',
+    summaryLabel: 'Today',
+    sum: (db) => sumToday('water', db),
+  },
+  {
+    id: 'steps',
+    label: 'Steps',
+    unit: 'steps',
+    targetKey: 'steps',
+    summaryLabel: 'Today',
+    sum: (db) => sumToday('steps', db),
+  },
+  {
+    id: 'caffeine',
+    label: 'Caffeine',
+    unit: 'mg',
+    targetKey: 'caffeine_mg',
+    summaryLabel: 'Week',
+    sum: (db) => sumWeek('caffeine', db),
+  },
+];
+
+const SECONDARY_ACTIONS = [
+  { id: 'meds', type: 'med', value: 1, unit: 'dose', label: 'Take meds', hint: 'Mark taken' },
+  { id: 'note', type: 'note', value: null, unit: null, label: 'Add note', hint: 'Remember this' },
+];
+
+const summaryRefs = new Map();
+const pendingStates = new Map();
+const queueLookup = new Map();
+const cleanupTimers = new Map();
+
+let queueSnapshot = getQueue();
+let lastDB = null;
+let unsubscribeStore = null;
+let unsubscribeQueue = null;
+let unsubscribeFlush = null;
+
+export function initQuickLog() {
+  const container = document.getElementById('quick-log');
+  const editGoals = document.getElementById('edit-goals');
+  if (!container) return;
+
+  initGoalsSheet();
+  render(container);
+  lastDB = getDB();
+  updateSummaries(lastDB);
+
+  if (editGoals) {
+    editGoals.addEventListener('click', () => openGoalsSheet());
+  }
+
+  if (typeof unsubscribeStore === 'function') {
+    unsubscribeStore();
+  }
+  unsubscribeStore = onChange((db) => {
+    lastDB = db;
+    updateSummaries(db);
+  });
+
+  if (typeof unsubscribeQueue === 'function') {
+    unsubscribeQueue();
+  }
+  unsubscribeQueue = onQueueChange((snapshot) => {
+    queueSnapshot = snapshot || [];
+    updateSummaries(lastDB);
+  });
+
+  if (typeof unsubscribeFlush === 'function') {
+    unsubscribeFlush();
+  }
+  unsubscribeFlush = onFlush(({ entry, log }) => {
+    const stateId = queueLookup.get(entry.id);
+    if (!stateId) return;
+    queueLookup.delete(entry.id);
+    const state = pendingStates.get(stateId);
+    if (state) {
+      state.committed = true;
+      state.logId = log?.id || state.logId;
+      state.queueId = null;
+    }
+  });
+}
+
+function render(container) {
+  container.innerHTML = '';
+  summaryRefs.clear();
+
+  GROUPS.forEach((group) => {
+    const section = document.createElement('section');
+    section.className = 'quick-log__section';
+    section.dataset.group = group.id;
+
+    const header = document.createElement('div');
+    header.className = 'quick-log__section-header';
+
+    const title = document.createElement('h4');
+    title.className = 'quick-log__section-title';
+    title.textContent = group.label;
+    header.appendChild(title);
+
+    const summary = document.createElement('p');
+    summary.className = 'quick-log__summary';
+    summary.dataset.summaryFor = group.id;
+    header.appendChild(summary);
+    section.appendChild(header);
+
+    const pillGrid = document.createElement('div');
+    pillGrid.className = 'quick-log__pills';
+    (PRESETS[group.id] || []).forEach((value) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'quick-log__pill card-hover card-press';
+      button.dataset.value = String(value);
+      button.dataset.group = group.id;
+      button.textContent = formatPillLabel(value, group.unit);
+      button.addEventListener('click', () => handlePrimaryAction(group, value));
+      pillGrid.appendChild(button);
+    });
+    section.appendChild(pillGrid);
+
+    summaryRefs.set(group.id, summary);
+    container.appendChild(section);
+  });
+
+  const secondary = document.createElement('div');
+  secondary.className = 'quick-log__secondary';
+  SECONDARY_ACTIONS.forEach((action) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'quick-log__pill quick-log__pill--secondary card-hover card-press';
+    button.dataset.actionId = action.id;
+    button.addEventListener('click', () => handleSecondaryAction(action));
+    button.innerHTML = `
+      <span class="quick-log__pill-label">${action.label}</span>
+      <span class="quick-log__pill-hint">${action.hint}</span>
+    `;
+    secondary.appendChild(button);
+  });
+  container.appendChild(secondary);
+}
+
+function handlePrimaryAction(group, value) {
+  const state = createState({
+    type: group.id,
+    value,
+    unit: group.unit,
+  });
+  pendingStates.set(state.id, state);
+
+  if (isOnline()) {
+    const log = pushLog({ type: group.id, value, unit: group.unit, source: 'quick' });
+    state.logId = log?.id || null;
+    state.committed = true;
+  } else {
+    const entry = enqueueOffline({ type: group.id, value, unit: group.unit, source: 'quick' });
+    state.queueId = entry.id;
+    queueLookup.set(entry.id, state.id);
+    queueSnapshot = getQueue();
+  }
+
+  updateSummaries(lastDB);
+  showToast(`Added ${formatPillLabel(value, group.unit)}`, {
+    undoLabel: 'Undo',
+    duration: TOAST_DURATION,
+    onUndo: () => handleUndo(state.id),
+  });
+  scheduleCleanup(state.id);
+}
+
+function handleSecondaryAction(action) {
+  if (action.type === 'note') {
+    const note = window.prompt('Add note');
+    if (!note) return;
+    const trimmed = note.trim();
+    if (!trimmed) return;
+    const log = pushLog({ type: 'note', value: null, unit: null, note: trimmed, source: 'quick' });
+    showToast('Added note', {
+      undoLabel: 'Undo',
+      duration: TOAST_DURATION,
+      onUndo: () => removeLog(log.id),
+    });
+    return;
+  }
+
+  const log = pushLog({ type: action.type, value: action.value, unit: action.unit, source: 'quick' });
+  showToast('Added meds', {
+    undoLabel: 'Undo',
+    duration: TOAST_DURATION,
+    onUndo: () => removeLog(log.id),
+  });
+}
+
+function handleUndo(stateId) {
+  const state = pendingStates.get(stateId);
+  if (!state) return;
+
+  if (!state.committed && state.queueId) {
+    removeOffline(state.queueId);
+    queueLookup.delete(state.queueId);
+    queueSnapshot = getQueue();
+    cleanupState(stateId);
+    updateSummaries(lastDB);
+    return;
+  }
+
+  if (state.committed && state.logId) {
+    removeLog(state.logId);
+  }
+  cleanupState(stateId);
+}
+
+function updateSummaries(db) {
+  const snapshot = db || lastDB || getDB();
+  const targets = snapshot?.targets || getTargets();
+  const queueTotals = getQueueTotals(queueSnapshot);
+
+  GROUPS.forEach((group) => {
+    const summaryEl = summaryRefs.get(group.id);
+    if (!summaryEl) return;
+    const total = Number(group.sum(snapshot) || 0) + (queueTotals[group.id] || 0);
+    const target = Number(targets[group.targetKey]) || 0;
+    summaryEl.textContent = buildSummaryText(group, total, target);
+  });
+}
+
+function buildSummaryText(group, total, target) {
+  const formattedTotal = `${formatNumber(total)} ${group.unit}`;
+  if (!target) {
+    return `${group.summaryLabel}: ${formattedTotal}`;
+  }
+  const formattedTarget = `${formatNumber(target)} ${group.unit}`;
+  const suffix = group.id === 'caffeine' ? 'ceiling' : 'target';
+  return `${group.summaryLabel}: ${formattedTotal} / ${formattedTarget} ${suffix}`;
+}
+
+function getQueueTotals(queue) {
+  return (queue || []).reduce((acc, item) => {
+    if (!item || typeof item.value !== 'number') return acc;
+    if (!GROUPS.some((group) => group.id === item.type)) return acc;
+    acc[item.type] = (acc[item.type] || 0) + Number(item.value || 0);
+    return acc;
+  }, {});
+}
+
+function formatPillLabel(value, unit) {
+  const number = formatNumber(value);
+  return `+${number} ${unit}`;
+}
+
+function formatNumber(value) {
+  return Number(value || 0).toLocaleString();
+}
+
+function createState(data) {
+  return {
+    id: createId(),
+    type: data.type,
+    value: data.value,
+    unit: data.unit,
+    queueId: null,
+    logId: null,
+    committed: false,
+  };
+}
+
+function createId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `quick_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+function isOnline() {
+  if (typeof navigator === 'undefined') return true;
+  return navigator.onLine !== false;
+}
+
+function scheduleCleanup(id) {
+  clearCleanup(id);
+  const timer = setTimeout(() => cleanupState(id), TOAST_DURATION + 500);
+  cleanupTimers.set(id, timer);
+}
+
+function cleanupState(id) {
+  clearCleanup(id);
+  const state = pendingStates.get(id);
+  if (state?.queueId) {
+    queueLookup.delete(state.queueId);
+  }
+  pendingStates.delete(id);
+}
+
+function clearCleanup(id) {
+  const timer = cleanupTimers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    cleanupTimers.delete(id);
+  }
+}
+
+function ready(callback) {
+  if (typeof document === 'undefined') return;
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', callback, { once: true });
+  } else {
+    callback();
+  }
+}
+
+ready(initQuickLog);

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -1,25 +1,12 @@
-import { getTargets, setTargets, listLogs, pushLog, removeLog, onChange } from './sharedStorage.js';
+import { listLogs, pushLog, removeLog, onChange } from './sharedStorage.js';
 import { getMedsToday, setMedsToday, updateMedToday, startOfDayISO } from './data-layer.js';
 
 export function initSidebar() {
-  const waterInput = document.getElementById('target-water');
-  const stepsInput = document.getElementById('target-steps');
-  const sleepInput = document.getElementById('target-sleep');
-  const caffeineInput = document.getElementById('target-caffeine');
   const medsList = document.getElementById('meds-list');
   const addMedButton = document.getElementById('add-med');
-  if (!waterInput || !stepsInput || !sleepInput || !caffeineInput || !medsList) return;
-
-  const inputs = [waterInput, stepsInput, sleepInput, caffeineInput];
-  const debouncedSave = debounce(saveTargets, 400);
+  if (!medsList) return;
 
   function render() {
-    const targets = getTargets();
-    waterInput.value = targets.water_ml;
-    stepsInput.value = targets.steps;
-    sleepInput.value = targets.sleep_min;
-    caffeineInput.value = targets.caffeine_mg;
-
     medsList.innerHTML = '';
     const meds = getMedsToday();
     const takenLogs = listLogs({ type: 'med', since: startOfDayISO(new Date()) });
@@ -52,10 +39,6 @@ export function initSidebar() {
     });
   }
 
-  inputs.forEach((input) => {
-    input.addEventListener('input', () => debouncedSave(inputs));
-  });
-
   if (addMedButton) {
     addMedButton.addEventListener('click', () => {
       const name = window.prompt('Medication name');
@@ -70,11 +53,6 @@ export function initSidebar() {
 
   render();
   onChange(render);
-}
-
-function saveTargets(inputs) {
-  const [water_ml, steps, sleep_min, caffeine_mg] = inputs.map((input) => Number(input.value || 0));
-  setTargets({ water_ml, steps, sleep_min, caffeine_mg });
 }
 
 function toggleMed(med, checked) {
@@ -109,14 +87,6 @@ function editMedName(med) {
 function removeMed(id) {
   const meds = getMedsToday().filter((med) => med.id !== id);
   setMedsToday(meds);
-}
-
-function debounce(fn, delay) {
-  let timer;
-  return (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => fn(...args), delay);
-  };
 }
 
 function createMedId() {

--- a/assets/js/summary-page.js
+++ b/assets/js/summary-page.js
@@ -3,7 +3,7 @@ import './summary-header.js';
 import './sidebar.js';
 import './hero-kpi.js';
 import './morning.js';
-import './quick-actions.js';
+import './quick-log.js';
 import './timeline.js';
 import './insights.js';
 import './streaks.js';


### PR DESCRIPTION
## Summary
- replace the Targets sidebar card with a Quick actions card that renders the water, steps, and caffeine quick log pills beside diary shortcuts
- implement the new quick log module with optimistic updates, offline queue flushing, and toast undo handling, powered by reusable day/week aggregation helpers
- add an Edit goals bottom sheet for updating presets or custom values and refresh Diary shortcuts to focus the add button when opened from Summary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7bc2054c4833294efee3ed2a50672