### PR TITLE
Make quick log pills more compact and accessible

### DIFF
--- a/assets/css/quick-log.css
+++ b/assets/css/quick-log.css
@@ -53,14 +53,16 @@
 
 .quick-log__section {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.5rem;
+  margin-block: 10px 14px;
 }
 
 .quick-log__section-header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.5rem 0.75rem;
+  gap: 8px;
+  margin-bottom: 8px;
   flex-wrap: wrap;
 }
 
@@ -73,30 +75,58 @@
 
 .quick-log__summary {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 13px;
   color: var(--muted, var(--color-muted));
+  opacity: 0.8;
 }
 
-.quick-log__pills {
+.quick-log__pills,
+.quick-log .pill-row {
   display: grid;
-  gap: 0.5rem 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(110px, 1fr));
+}
+
+@media (max-width: 480px) {
+  .quick-log__pills,
+  .quick-log .pill-row {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
 }
 
 .quick-log__pill {
-  min-height: 48px;
-  padding: 0.65rem 0.9rem;
+  height: var(--pill-h, auto);
+  padding: 0 var(--pill-px, 0.9rem);
   border-radius: 999px;
   border: 1px solid rgba(37, 99, 235, 0.2);
   background: rgba(37, 99, 235, 0.08);
   color: var(--text, var(--color-heading));
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: var(--pill-fs, 0.95rem);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.pill--compact {
+  --pill-h: 44px;
+  --pill-fs: 15px;
+  --pill-px: 12px;
+  height: var(--pill-h);
+  padding: 0 var(--pill-px);
+  font-size: var(--pill-fs);
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.pill--compact:focus-visible {
+  outline: 2px solid var(--primary, var(--color-primary, #2563eb));
+  outline-offset: 2px;
 }
 
 .quick-log__pill:hover {
@@ -141,6 +171,8 @@
   padding: 0.75rem 1rem;
   flex-direction: column;
   text-align: center;
+  white-space: normal;
+  height: auto;
 }
 
 .quick-log__links {


### PR DESCRIPTION
## Summary
- shrink the quick action pill layout with a compact pill token and responsive three/two column grid
- display abbreviated quick action amounts while adding aria-labels for full context and consistent toast messaging
- shorten quick log summaries with Intl.NumberFormat conversions so totals and targets stay on one line

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7d11d80648332ac927e084ab44413