### PR TITLE
Remove quick links tiles and tighten quick log card spacing

### DIFF
--- a/Summary.html
+++ b/Summary.html
@@ -201,24 +201,6 @@
                 </button>
               </header>
               <div class="quick-log" id="quick-log" role="group" aria-label="Quick actions"></div>
-              <div class="quick-log__links" id="quick-log-links" role="group" aria-label="Diary shortcuts">
-                <a
-                  class="quick-log__link card-press card-hover"
-                  data-section="meds"
-                  href="Diary.html?section=meds&amp;date=today"
-                >
-                  <span class="quick-log__link-title">Meds today</span>
-                  <span class="quick-log__link-hint">Review and adjust doses</span>
-                </a>
-                <a
-                  class="quick-log__link card-press card-hover"
-                  data-section="food"
-                  href="Diary.html?section=food&amp;date=today&amp;action=add"
-                >
-                  <span class="quick-log__link-title">Meals</span>
-                  <span class="quick-log__link-hint">Log a meal or snack</span>
-                </a>
-              </div>
             </section>
             <section class="sidebar-section" aria-labelledby="meds-heading">
               <header>

--- a/assets/css/quick-log.css
+++ b/assets/css/quick-log.css
@@ -49,6 +49,16 @@
 .quick-log {
   display: grid;
   gap: clamp(1rem, 1.5vw, 1.25rem);
+  min-height: auto;
+  height: auto;
+}
+
+.quick-log::after {
+  content: none;
+}
+
+.quick-log .card__body {
+  padding-bottom: 12px;
 }
 
 .quick-log__section {
@@ -173,6 +183,10 @@
   text-align: center;
   white-space: normal;
   height: auto;
+}
+
+.sidebar .card:last-child {
+  margin-bottom: 0;
 }
 
 .quick-log__links {


### PR DESCRIPTION
## Summary
- remove the Meds today and Meals quick link tiles from the summary sidebar
- loosen the quick log card styling so its border hugs the content without extra space

## Testing
- npm start *(fails: blocked from downloading serve package)*

------
https://chatgpt.com/codex/tasks/task_e_68e7fc672e6c83329c6fbad6b94bb4b9