### PR TITLE
Refine quick log layout

### DIFF
--- a/assets/css/quick-log.css
+++ b/assets/css/quick-log.css
@@ -1,19 +1,14 @@
+:root {
+  --pillW: 96px;
+  --pillH: 36px;
+}
+
 .sidebar-section--quick-log {
   display: grid;
   gap: clamp(1rem, 1.5vw, 1.5rem);
 }
 
 .sidebar-section--quick-log > * {
-  margin-left: 0 !important;
-  margin-right: 0 !important;
-}
-
-.quick-log__header,
-.quick-log__section,
-.quick-log__secondary {
-  padding-left: 16px;
-  padding-right: 12px;
-  text-align: left;
   margin-left: 0 !important;
   margin-right: 0 !important;
 }
@@ -57,136 +52,84 @@
   content: none;
 }
 
-.quick-log__section {
-  display: grid;
-  gap: 0.5rem;
-  margin-block: 10px 14px;
+.quick-log .card__head,
+.quick-log .card__body {
+  padding-left: 16px;
+  padding-right: 12px;
+  text-align: left;
 }
 
-.quick-log__section-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 8px;
-  flex-wrap: wrap;
+.quick-log,
+.quick-log .card__body,
+.quick-log .pill-row {
+  margin-left: 0;
+  margin-right: 0;
 }
 
-.quick-log__section-title {
+.quick-log .ql-section {
+  margin: 12px 0 16px;
+}
+
+.quick-log .ql-head {
+  margin-bottom: 6px;
+}
+
+.quick-log .ql-head h4 {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
   color: var(--text, var(--color-heading));
 }
 
-.quick-log__summary {
-  margin: 0;
+.quick-log .ql-meta {
   font-size: 13px;
+  opacity: 0.85;
+  margin-top: 2px;
   color: var(--muted, var(--color-muted));
-  opacity: 0.8;
-  text-align: left;
 }
 
-.quick-log__pills,
 .quick-log .pill-row {
   display: grid;
+  grid-template-columns: repeat(3, var(--pillW));
   gap: 8px;
-  grid-template-columns: repeat(4, minmax(88px, 1fr));
   justify-content: start;
-  justify-items: start;
-  align-items: center;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
-}
-
-@media (max-width: 1024px) {
-  .quick-log__pills,
-  .quick-log .pill-row {
-    grid-template-columns: repeat(3, minmax(88px, 1fr));
-  }
 }
 
 @media (max-width: 480px) {
-  .quick-log__pills,
   .quick-log .pill-row {
-    grid-template-columns: repeat(2, minmax(100px, 1fr));
+    grid-template-columns: repeat(2, var(--pillW));
   }
 }
 
-.quick-log__pill {
-  height: var(--pill-h, auto);
-  padding: 0 var(--pill-px, 0.9rem);
-  border-radius: 999px;
+.pill {
+  width: var(--pillW);
+  height: var(--pillH);
+  padding: 0 10px;
+  border-radius: 9999px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
   border: 1px solid rgba(37, 99, 235, 0.2);
   background: rgba(37, 99, 235, 0.08);
   color: var(--text, var(--color-heading));
   font-weight: 600;
-  font-size: var(--pill-fs, 0.95rem);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-  width: auto;
-  max-width: 100%;
 }
 
-.pill--compact {
-  height: 40px;
-  padding: 0 10px;
-  font-size: 14px;
-  white-space: nowrap;
-}
-
-.pill--compact:focus-visible {
-  outline: 2px solid var(--primary, var(--color-primary, #2563eb));
-  outline-offset: 2px;
-}
-
-.quick-log__pill:hover {
+.pill:hover {
   background: rgba(37, 99, 235, 0.14);
   border-color: rgba(37, 99, 235, 0.32);
 }
 
-.quick-log__pill:active {
+.pill:active {
   transform: translateY(1px);
 }
 
-.quick-log__pill:focus-visible {
+.pill:focus-visible {
   outline: 3px solid var(--color-focus, rgba(37, 99, 235, 0.65));
   outline-offset: 2px;
-}
-
-.quick-log__pill--secondary {
-  background: rgba(15, 23, 42, 0.06);
-  border-color: rgba(148, 163, 184, 0.35);
-}
-
-.quick-log__pill-label {
-  display: block;
-  font-weight: 600;
-}
-
-.quick-log__pill-hint {
-  display: block;
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--muted, var(--color-muted));
-}
-
-.quick-log__secondary {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.quick-log__secondary .quick-log__pill {
-  width: 100%;
-  min-height: 56px;
-  padding: 0.75rem 1rem;
-  flex-direction: column;
-  text-align: center;
-  white-space: normal;
-  height: auto;
 }
 
 .sidebar .card:last-child {
@@ -237,35 +180,7 @@
     align-items: stretch;
   }
 
-  .quick-log__section-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .quick-log__summary {
-    font-size: 0.8rem;
-  }
-
-  .quick-log__pills {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .quick-log__pill {
-    min-height: 52px;
-    font-size: 1rem;
-  }
-
   .quick-log__links {
     grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 420px) {
-  .quick-log__pill {
-    min-height: 56px;
-  }
-
-  .quick-log__secondary .quick-log__pill {
-    min-height: 60px;
   }
 }


### PR DESCRIPTION
## Summary
- simplify the quick log to only render hydration, steps, and caffeine presets with metadata directly under each heading
- restyle the quick log pills into a fixed-width grid that aligns to the left and tightens sidebar spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8067cc3a48332abdafca57e581629