### PR TITLE
Tighten quick log layout

### DIFF
--- a/Summary.html
+++ b/Summary.html
@@ -194,13 +194,6 @@
               </header>
               <div class="quick-log" id="quick-log" role="group" aria-label="Quick actions"></div>
             </section>
-            <section class="sidebar-section" aria-labelledby="meds-heading">
-              <header>
-                <h3 id="meds-heading">Today&apos;s meds</h3>
-                <button type="button" id="add-med" class="card-press">Add</button>
-              </header>
-              <div class="meds-list" id="meds-list" aria-live="polite"></div>
-            </section>
           </aside>
         </div>
         <footer class="summary-footer" role="contentinfo">

--- a/assets/css/quick-log.css
+++ b/assets/css/quick-log.css
@@ -1,3 +1,4 @@
+/* компактные чипы */
 :root {
   --pillW: 96px;
   --pillH: 36px;
@@ -66,8 +67,20 @@
   margin-right: 0;
 }
 
+/* Контент карточки Quick actions не шире комфортного контейнера */
+.quick-log .card__body {
+  max-width: 420px;
+  margin-left: 0;
+}
+
+@media (max-width: 480px) {
+  .quick-log .card__body {
+    max-width: 100%;
+  }
+}
+
 .quick-log .ql-section {
-  margin: 12px 0 16px;
+  margin: 10px 0 14px;
 }
 
 .quick-log .ql-head {
@@ -93,6 +106,7 @@
   grid-template-columns: repeat(3, var(--pillW));
   gap: 8px;
   justify-content: start;
+  justify-items: start;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- limit the Quick actions card body to a stable width and keep its content left aligned
- enforce the compact 3/2 pill grid with adjusted spacing and typography
- remove the unused Today’s meds sidebar section so only Water/Steps/Caffeine remain

## Testing
- npm start *(fails: 403 Forbidden fetching serve)*

------
https://chatgpt.com/codex/tasks/task_e_68e809e7c5e48332be7c9cf536bb95c1