### PR TITLE
Add navigation updates and new device/emergency/program pages

### DIFF
--- a/Device.html
+++ b/Device.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Device</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+  </head>
+  <body class="app-shell" data-page="device">
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
+    <main class="app-main">
+      <div class="container flow">
+        <section class="card hero">
+          <h2>Device</h2>
+          <p>Manage connected sources, sync status and calibration.</p>
+        </section>
+
+        <div class="section-grid section-grid--two">
+          <section class="card stack">
+            <h3>Connected sources</h3>
+            <ul class="panel-list device-sources">
+              <li class="panel-list__item">
+                <div class="device-source__info">
+                  <span class="device-source__name">WearOS</span>
+                  <div class="device-source__meta">
+                    <span>Status: Online</span>
+                    <span>Last sync: 2 minutes ago</span>
+                    <span>Battery: 78%</span>
+                  </div>
+                </div>
+                <span class="status-pill status-pill--online">Online</span>
+              </li>
+              <li class="panel-list__item">
+                <div class="device-source__info">
+                  <span class="device-source__name">Apple Health</span>
+                  <div class="device-source__meta">
+                    <span>Status: Online</span>
+                    <span>Last sync: 5 minutes ago</span>
+                    <span>Battery: 92%</span>
+                  </div>
+                </div>
+                <span class="status-pill status-pill--online">Online</span>
+              </li>
+              <li class="panel-list__item">
+                <div class="device-source__info">
+                  <span class="device-source__name">Google Fit</span>
+                  <div class="device-source__meta">
+                    <span>Status: Offline</span>
+                    <span>Last sync: Yesterday, 22:14</span>
+                    <span>Battery: 41%</span>
+                  </div>
+                </div>
+                <span class="status-pill status-pill--offline">Offline</span>
+              </li>
+              <li class="panel-list__item">
+                <div class="device-source__info">
+                  <span class="device-source__name">Manual</span>
+                  <div class="device-source__meta">
+                    <span>Status: Manual input</span>
+                    <span>Last sync: 3 days ago</span>
+                    <span>Battery: —</span>
+                  </div>
+                </div>
+                <span class="status-pill status-pill--manual">Manual</span>
+              </li>
+            </ul>
+          </section>
+
+          <section class="card stack">
+            <h3>Controls</h3>
+            <div class="button-row">
+              <button class="btn btn--primary" type="button">Resync now</button>
+              <button class="btn btn--ghost" type="button">Background sync ⏼</button>
+            </div>
+            <div class="stack">
+              <span class="muted">Units</span>
+              <div class="chip-row" role="group" aria-label="Preferred measurement units">
+                <button class="chip active" type="button">ml/L</button>
+                <button class="chip" type="button">mg</button>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <section class="card stack">
+          <h3>Calibration</h3>
+          <form class="calibration-grid" action="#" method="post">
+            <label class="form-field">
+              <span>Height</span>
+              <input class="input" type="number" name="height" placeholder="cm" min="0" />
+            </label>
+            <label class="form-field">
+              <span>Weight</span>
+              <input class="input" type="number" name="weight" placeholder="kg" min="0" />
+            </label>
+            <label class="form-field">
+              <span>Stride length</span>
+              <input class="input" type="number" name="stride" placeholder="cm" min="0" />
+            </label>
+          </form>
+        </section>
+
+        <section class="card stack">
+          <h3>Sync logs</h3>
+          <div class="table-wrapper" role="region" aria-label="Latest sync attempts">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Time</th>
+                  <th scope="col">Source</th>
+                  <th scope="col">Result</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>2024-07-16 09:42</td><td>WearOS</td><td>Success</td></tr>
+                <tr><td>2024-07-16 09:17</td><td>Apple Health</td><td>Success</td></tr>
+                <tr><td>2024-07-16 08:58</td><td>Google Fit</td><td>Timeout</td></tr>
+                <tr><td>2024-07-16 08:40</td><td>Manual</td><td>Updated hydration</td></tr>
+                <tr><td>2024-07-16 08:10</td><td>WearOS</td><td>Success</td></tr>
+                <tr><td>2024-07-16 07:55</td><td>Apple Health</td><td>Success</td></tr>
+                <tr><td>2024-07-16 07:32</td><td>Google Fit</td><td>Auth required</td></tr>
+                <tr><td>2024-07-16 06:58</td><td>WearOS</td><td>Success</td></tr>
+                <tr><td>2024-07-16 06:11</td><td>Apple Health</td><td>Success</td></tr>
+                <tr><td>2024-07-16 05:42</td><td>Manual</td><td>Logged caffeine</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+    <script src="./assets/js/includes.js" defer></script>
+  </body>
+</html>

--- a/Doctor.html
+++ b/Doctor.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Doctor</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+    <link rel="stylesheet" href="./assets/css/modal.css" />
+  </head>
+  <body class="app-shell" data-page="doctor">
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
+    <main class="app-main">
+      <div class="container flow">
+        <section class="card hero">
+          <h2>Doctor</h2>
+          <p>Share progress summaries and control how your clinician views your data.</p>
+        </section>
+
+        <div class="section-grid section-grid--two">
+          <section class="card stack">
+            <h3>Share access</h3>
+            <p class="muted">Create a secure link to provide your doctor with temporary dashboard access.</p>
+            <div class="button-row">
+              <button class="btn btn--primary" type="button">Generate link</button>
+              <button class="btn btn--ghost" type="button">Copy</button>
+            </div>
+          </section>
+
+          <section class="card stack">
+            <h3>Report template</h3>
+            <p class="muted">Choose the snapshot your doctor receives by default.</p>
+            <div class="chip-row" role="group" aria-label="Report range">
+              <button class="chip active" type="button">7 days</button>
+              <button class="chip" type="button">30 days</button>
+            </div>
+            <ul class="simple-list" aria-label="Metrics included">
+              <li>Hydration trend</li>
+              <li>Daily steps</li>
+              <li>Resting heart rate</li>
+              <li>Sleep duration</li>
+              <li>Caffeine intake</li>
+            </ul>
+          </section>
+        </div>
+
+        <div class="section-grid section-grid--two">
+          <section class="card stack">
+            <h3>Export</h3>
+            <p class="muted">Download or share recent health summaries in a single tap.</p>
+            <div class="button-row">
+              <button class="btn btn--primary" type="button">PDF</button>
+              <button class="btn btn--ghost" type="button">CSV</button>
+              <button class="btn" type="button">View link</button>
+            </div>
+          </section>
+
+          <section class="card stack">
+            <h3>Scheduled email</h3>
+            <p class="muted">Send automatic updates directly to your doctor.</p>
+            <label class="toggle">
+              <input type="checkbox" checked />
+              Weekly digest
+            </label>
+            <label class="form-field">
+              <span>Doctor email</span>
+              <input class="input" type="email" name="doctor-email" placeholder="doctor@clinic.io" />
+            </label>
+          </section>
+        </div>
+      </div>
+    </main>
+
+    <div id="pro-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="pro-modal-title">
+      <div class="modal__box">
+        <h3 id="pro-modal-title">Pro feature</h3>
+        <p>Doctor/Programs are available on Pro. Start trial?</p>
+        <div class="modal__actions">
+          <button id="pro-start" class="btn btn--primary" type="button">Start trial</button>
+          <button id="pro-later" class="btn" type="button">Maybe later</button>
+        </div>
+      </div>
+    </div>
+
+    <script src="./assets/js/includes.js" defer></script>
+    <script type="module">
+      import { requireProOrRedirect } from './assets/js/gating.js';
+
+      requireProOrRedirect();
+    </script>
+  </body>
+</html>

--- a/Emergency.html
+++ b/Emergency.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Emergency</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+  </head>
+  <body class="app-shell" data-page="emergency">
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
+    <main class="app-main">
+      <div class="container flow">
+        <section class="card hero">
+          <h2>Emergency</h2>
+          <p>Keep critical health details ready for responders and close contacts.</p>
+        </section>
+
+        <section class="card stack">
+          <h3>ICE card</h3>
+          <div class="calibration-grid">
+            <label class="form-field">
+              <span>Name</span>
+              <input class="input" type="text" name="ice-name" placeholder="Jane Cooper" />
+            </label>
+            <label class="form-field">
+              <span>ICE contact</span>
+              <input class="input" type="tel" name="ice-contact" placeholder="+1 (555) 123-4567" />
+            </label>
+            <label class="form-field">
+              <span>Allergies</span>
+              <textarea class="input" name="ice-allergies" rows="3" placeholder="Penicillin, tree nuts"></textarea>
+            </label>
+            <label class="form-field">
+              <span>Meds snapshot</span>
+              <textarea class="input" name="ice-meds" rows="3" placeholder="Metformin 500mg, Lisinopril 10mg"></textarea>
+            </label>
+          </div>
+        </section>
+
+        <section class="card stack">
+          <h3>Quick actions</h3>
+          <div class="button-row">
+            <button class="btn btn--primary" type="button">Show large QR</button>
+            <button class="btn btn--ghost" type="button">Download PDF</button>
+          </div>
+        </section>
+      </div>
+    </main>
+    <script src="./assets/js/includes.js" defer></script>
+  </body>
+</html>

--- a/Programs.html
+++ b/Programs.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Programs</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+    <link rel="stylesheet" href="./assets/css/modal.css" />
+  </head>
+  <body class="app-shell" data-page="programs">
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
+    <main class="app-main">
+      <div class="container flow">
+        <section class="card hero">
+          <h2>Programs</h2>
+          <p>Activate guided routines to stay accountable and compound healthy habits.</p>
+        </section>
+
+        <section class="card stack">
+          <h3>Mini programs</h3>
+          <p class="muted">Choose a focus area and follow lightweight daily tasks.</p>
+          <ul class="panel-list" aria-label="Available programs">
+            <li class="panel-list__item">
+              <div>
+                <span class="panel-list__title">Hydration 7-day</span>
+                <div class="panel-list__meta">
+                  <span>Progress: Day 3 of 7</span>
+                  <span>Focus: +250 ml above baseline</span>
+                </div>
+              </div>
+              <div class="panel-list__actions">
+                <button class="btn btn--primary" type="button">Continue</button>
+              </div>
+            </li>
+            <li class="panel-list__item">
+              <div>
+                <span class="panel-list__title">10k steps 5/7</span>
+                <div class="panel-list__meta">
+                  <span>Progress: Week 2 of 4</span>
+                  <span>Goal: 5 days ≥ 10,000 steps</span>
+                </div>
+              </div>
+              <div class="panel-list__actions">
+                <button class="btn" type="button">Start</button>
+              </div>
+            </li>
+            <li class="panel-list__item">
+              <div>
+                <span class="panel-list__title">Caffeine taper 14-day</span>
+                <div class="panel-list__meta">
+                  <span>Progress: Not started</span>
+                  <span>Outcome: Gradual reduction plan</span>
+                </div>
+              </div>
+              <div class="panel-list__actions">
+                <button class="btn" type="button">Start</button>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <section class="card stack">
+          <h3>Daily focus</h3>
+          <ul class="simple-list" aria-label="Today&#39;s suggested actions">
+            <li>Log wake-up hydration check-in</li>
+            <li>Schedule a 15-minute walk after lunch</li>
+            <li>Swap afternoon coffee for herbal tea</li>
+          </ul>
+        </section>
+      </div>
+    </main>
+
+    <div id="pro-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="pro-modal-title">
+      <div class="modal__box">
+        <h3 id="pro-modal-title">Pro feature</h3>
+        <p>Doctor/Programs are available on Pro. Start trial?</p>
+        <div class="modal__actions">
+          <button id="pro-start" class="btn btn--primary" type="button">Start trial</button>
+          <button id="pro-later" class="btn" type="button">Maybe later</button>
+        </div>
+      </div>
+    </div>
+
+    <script src="./assets/js/includes.js" defer></script>
+    <script type="module">
+      import { requireProOrRedirect } from './assets/js/gating.js';
+
+      requireProOrRedirect();
+    </script>
+  </body>
+</html>

--- a/Reports.html
+++ b/Reports.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reports</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+  </head>
+  <body class="app-shell" data-page="reports">
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
+    <main class="app-main">
+      <div class="container flow">
+        <section class="card hero">
+          <h2>Reports</h2>
+          <p>Review generated insights and keep track of exports for your care team.</p>
+        </section>
+
+        <section class="card stack">
+          <div class="button-row button-row--end">
+            <button class="btn btn--primary" type="button">Generate new report</button>
+          </div>
+          <ul class="panel-list" aria-label="Generated reports">
+            <li class="panel-list__item">
+              <div>
+                <span class="panel-list__title">Report • July 16, 2024</span>
+                <div class="panel-list__meta">
+                  <span>Period: July 9 – July 15</span>
+                  <span>Generated 08:05</span>
+                </div>
+              </div>
+              <div class="panel-list__actions">
+                <button class="btn btn--ghost" type="button">View</button>
+                <button class="btn" type="button">Download PDF</button>
+                <button class="btn" type="button">Delete</button>
+              </div>
+            </li>
+            <li class="panel-list__item">
+              <div>
+                <span class="panel-list__title">Report • July 09, 2024</span>
+                <div class="panel-list__meta">
+                  <span>Period: July 2 – July 8</span>
+                  <span>Generated 09:12</span>
+                </div>
+              </div>
+              <div class="panel-list__actions">
+                <button class="btn btn--ghost" type="button">View</button>
+                <button class="btn" type="button">Download PDF</button>
+                <button class="btn" type="button">Delete</button>
+              </div>
+            </li>
+            <li class="panel-list__item">
+              <div>
+                <span class="panel-list__title">Report • July 02, 2024</span>
+                <div class="panel-list__meta">
+                  <span>Period: June 25 – July 1</span>
+                  <span>Generated 08:47</span>
+                </div>
+              </div>
+              <div class="panel-list__actions">
+                <button class="btn btn--ghost" type="button">View</button>
+                <button class="btn" type="button">Download PDF</button>
+                <button class="btn" type="button">Delete</button>
+              </div>
+            </li>
+            <li class="panel-list__item">
+              <div>
+                <span class="panel-list__title">Report • June 25, 2024</span>
+                <div class="panel-list__meta">
+                  <span>Period: June 18 – June 24</span>
+                  <span>Generated 07:55</span>
+                </div>
+              </div>
+              <div class="panel-list__actions">
+                <button class="btn btn--ghost" type="button">View</button>
+                <button class="btn" type="button">Download PDF</button>
+                <button class="btn" type="button">Delete</button>
+              </div>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </main>
+    <script src="./assets/js/includes.js" defer></script>
+  </body>
+</html>

--- a/Settings.html
+++ b/Settings.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Settings</title>
+    <link rel="stylesheet" href="./shared/styles.css" />
+  </head>
+  <body class="app-shell" data-page="settings">
+    <aside id="sidenav" class="sidebar" aria-label="Primary navigation"></aside>
+    <main class="app-main">
+      <div class="container flow">
+        <section class="card hero">
+          <h2>Settings</h2>
+          <p>Adjust your profile, preferences and privacy in one place.</p>
+        </section>
+
+        <section class="card stack">
+          <h3>Profile</h3>
+          <div class="calibration-grid">
+            <label class="form-field">
+              <span>Name</span>
+              <input class="input" type="text" name="profile-name" placeholder="Jane Cooper" />
+            </label>
+            <label class="form-field">
+              <span>Timezone</span>
+              <select class="input" name="profile-timezone">
+                <option value="utc-5">UTC-05:00 Eastern</option>
+                <option value="utc-8">UTC-08:00 Pacific</option>
+                <option value="utc+1">UTC+01:00 Central Europe</option>
+              </select>
+            </label>
+            <label class="form-field">
+              <span>Theme</span>
+              <select class="input" name="profile-theme">
+                <option value="system">System default</option>
+                <option value="dark">Dark</option>
+                <option value="light">Light</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section class="card stack">
+          <h3>Goals</h3>
+          <p class="muted">Tune your daily targets for smarter nudges.</p>
+          <div class="calibration-grid">
+            <div class="stack">
+              <span class="muted">Water</span>
+              <div class="chip-row" role="group" aria-label="Water goal presets">
+                <button class="chip active" type="button">2.5 L</button>
+                <button class="chip" type="button">3.0 L</button>
+                <button class="chip" type="button">Custom</button>
+              </div>
+            </div>
+            <div class="stack">
+              <span class="muted">Steps</span>
+              <div class="chip-row" role="group" aria-label="Step goal presets">
+                <button class="chip active" type="button">10k</button>
+                <button class="chip" type="button">12k</button>
+                <button class="chip" type="button">Custom</button>
+              </div>
+            </div>
+            <div class="stack">
+              <span class="muted">Caffeine</span>
+              <div class="chip-row" role="group" aria-label="Caffeine goal presets">
+                <button class="chip active" type="button">200 mg</button>
+                <button class="chip" type="button">300 mg</button>
+                <button class="chip" type="button">Off</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="card stack">
+          <h3>Notifications</h3>
+          <p class="muted">Select the reminders you want to receive.</p>
+          <label class="toggle">
+            <input type="checkbox" checked />
+            Water intake reminders
+          </label>
+          <label class="toggle">
+            <input type="checkbox" />
+            Medication reminders
+          </label>
+          <label class="toggle">
+            <input type="checkbox" checked />
+            Step cadence nudges
+          </label>
+        </section>
+
+        <section class="card stack">
+          <h3>Privacy &amp; data</h3>
+          <p class="muted">Control exports or wipe this device&#39;s local copy.</p>
+          <div class="button-row">
+            <button class="btn btn--ghost" type="button">Export data</button>
+            <button class="btn" type="button">Clear local data</button>
+          </div>
+        </section>
+      </div>
+    </main>
+    <script src="./assets/js/includes.js" defer></script>
+  </body>
+</html>

--- a/assets/css/modal.css
+++ b/assets/css/modal.css
@@ -1,0 +1,58 @@
+.hidden {
+  display: none !important;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none !important;
+}
+
+.modal__box {
+  width: min(520px, 92vw);
+  background: #0f172a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 20px;
+  display: grid;
+  gap: 16px;
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.55);
+}
+
+.modal__box h3 {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.modal__box p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.82);
+  line-height: 1.5;
+}
+
+.modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+@media (max-width: 480px) {
+  .modal__actions {
+    justify-content: flex-start;
+  }
+
+  .modal__actions .btn,
+  .modal__actions .btn--primary {
+    width: 100%;
+  }
+}

--- a/assets/js/appState.js
+++ b/assets/js/appState.js
@@ -1,0 +1,3 @@
+export const appState = {
+  isPro: false, // TODO: replace with persisted flag
+};

--- a/assets/js/gating.js
+++ b/assets/js/gating.js
@@ -1,0 +1,33 @@
+import { appState } from './appState.js';
+
+function hideModal(modal) {
+  modal.classList.add('hidden');
+}
+
+export function requireProOrRedirect() {
+  if (typeof document === 'undefined') return;
+  const modal = document.getElementById('pro-modal');
+  if (!modal) return;
+
+  const later = document.getElementById('pro-later');
+  const start = document.getElementById('pro-start');
+
+  if (!appState.isPro) {
+    modal.classList.remove('hidden');
+
+    if (later) {
+      later.onclick = () => {
+        hideModal(modal);
+        window.location.href = 'Summary.html';
+      };
+    }
+
+    if (start) {
+      start.onclick = () => {
+        hideModal(modal);
+      };
+    }
+  } else {
+    hideModal(modal);
+  }
+}

--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -70,7 +70,12 @@
     if (!container || typeof document === 'undefined') return;
     const file = (window.location?.pathname || '').split('/').pop().toLowerCase();
     const route = (file || 'index.html').replace('.html', '');
-    const normalizedRoute = route === 'diaryplus' ? 'diary' : route;
+    const normalizedRoute =
+      route === 'diaryplus'
+        ? 'diary'
+        : route === 'index'
+        ? 'summary'
+        : route || 'summary';
     container.querySelectorAll('a[data-route]').forEach((link) => {
       const isActive = (link.dataset.route || '').toLowerCase() === normalizedRoute;
       link.classList.toggle('is-active', isActive);

--- a/includes/nav.html
+++ b/includes/nav.html
@@ -2,12 +2,74 @@
   <div class="brand">
     <a class="brand-link" href="Summary.html">Health • 2099</a>
   </div>
-
-  <nav class="nav" aria-label="Primary">
-    <a href="Summary.html" data-nav="summary" class="nav-link"><span>Summary</span></a>
-    <a href="HealthCabinet.html" data-nav="health" class="nav-link"><span>Health cabinet</span></a>
-  <a href="Diary.html" data-nav="diary" class="nav-link"><span>Diary</span></a>
-    <a href="Map.html" data-nav="map" class="nav-link"><span>Map</span></a>
+  <nav class="nav" aria-label="Primary navigation">
+    <ul class="nav-list">
+      <li class="nav-item">
+        <a href="Summary.html" data-nav="summary" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">📈</span>
+          <span class="nav-txt">Summary</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="HealthCabinet.html" data-nav="healthcabinet" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">🧬</span>
+          <span class="nav-txt">Health cabinet</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="Diary.html" data-nav="diary" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">📝</span>
+          <span class="nav-txt">Diary</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="Map.html" data-nav="map" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">🗺️</span>
+          <span class="nav-txt">Map</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="Device.html" data-nav="device" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">🔌</span>
+          <span class="nav-txt">Device</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="Doctor.html" data-nav="doctor" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">🩺</span>
+          <span class="nav-txt">Doctor</span>
+          <span class="badge-pro">Pro</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="Reports.html" data-nav="reports" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">📊</span>
+          <span class="nav-txt">Reports</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="Programs.html" data-nav="programs" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">🎯</span>
+          <span class="nav-txt">Programs</span>
+          <span class="badge-pro">Pro</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="Emergency.html" data-nav="emergency" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">🚑</span>
+          <span class="nav-txt">Emergency</span>
+        </a>
+      </li>
+    </ul>
+    <div class="nav-divider" role="presentation" aria-hidden="true"></div>
+    <ul class="nav-list nav-bottom">
+      <li class="nav-item">
+        <a href="Settings.html" data-nav="settings" class="nav-link">
+          <span class="nav-ico" aria-hidden="true">⚙️</span>
+          <span class="nav-txt">Settings</span>
+        </a>
+      </li>
+    </ul>
   </nav>
 </aside>
 <script src="/Health2099/assets/topbar.bundle.js" defer></script>

--- a/partials/sidenav.html
+++ b/partials/sidenav.html
@@ -2,20 +2,71 @@
   <a class="brand-link" href="Summary.html">Health • 2099</a>
 </div>
 <nav class="nav" aria-label="Primary navigation">
-  <a class="nav-link" data-route="summary" href="Summary.html">
-    <span aria-hidden="true">📈</span>
-    <span>Summary</span>
-  </a>
-  <a class="nav-link" data-route="healthcabinet" href="HealthCabinet.html">
-    <span aria-hidden="true">🧬</span>
-    <span>Health cabinet</span>
-  </a>
-  <a class="nav-link" data-route="diary" href="Diary.html">
-    <span aria-hidden="true">📝</span>
-    <span>Diary</span>
-  </a>
-  <a class="nav-link" data-route="map" href="Map.html">
-    <span aria-hidden="true">🗺️</span>
-    <span>Map</span>
-  </a>
+  <ul class="nav-list">
+    <li class="nav-item">
+      <a class="nav-link" data-route="summary" href="Summary.html">
+        <span class="nav-ico" aria-hidden="true">📈</span>
+        <span class="nav-txt">Summary</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="healthcabinet" href="HealthCabinet.html">
+        <span class="nav-ico" aria-hidden="true">🧬</span>
+        <span class="nav-txt">Health cabinet</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="diary" href="Diary.html">
+        <span class="nav-ico" aria-hidden="true">📝</span>
+        <span class="nav-txt">Diary</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="map" href="Map.html">
+        <span class="nav-ico" aria-hidden="true">🗺️</span>
+        <span class="nav-txt">Map</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="device" href="Device.html">
+        <span class="nav-ico" aria-hidden="true">🔌</span>
+        <span class="nav-txt">Device</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="doctor" href="Doctor.html">
+        <span class="nav-ico" aria-hidden="true">🩺</span>
+        <span class="nav-txt">Doctor</span>
+        <span class="badge-pro">Pro</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="reports" href="Reports.html">
+        <span class="nav-ico" aria-hidden="true">📊</span>
+        <span class="nav-txt">Reports</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="programs" href="Programs.html">
+        <span class="nav-ico" aria-hidden="true">🎯</span>
+        <span class="nav-txt">Programs</span>
+        <span class="badge-pro">Pro</span>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-route="emergency" href="Emergency.html">
+        <span class="nav-ico" aria-hidden="true">🚑</span>
+        <span class="nav-txt">Emergency</span>
+      </a>
+    </li>
+  </ul>
+  <div class="nav-divider" role="presentation" aria-hidden="true"></div>
+  <ul class="nav-list nav-bottom">
+    <li class="nav-item">
+      <a class="nav-link" data-route="settings" href="Settings.html">
+        <span class="nav-ico" aria-hidden="true">⚙️</span>
+        <span class="nav-txt">Settings</span>
+      </a>
+    </li>
+  </ul>
 </nav>

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -217,21 +217,72 @@ a:focus {
   text-decoration: none;
 }
 
+
 .nav {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 16px;
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
+.nav-item {
+  width: 100%;
+}
+
 .nav-link {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 0.75rem;
   padding: 0.65rem 0.75rem;
   color: var(--color-nav-text);
   text-decoration: none;
   border-radius: 12px;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.nav-ico {
+  font-size: 1.15rem;
+  width: 1.75rem;
+  display: grid;
+  place-items: center;
+}
+
+.nav-txt {
+  flex: 1 1 auto;
+  font-weight: 500;
+}
+
+.nav-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.badge-pro {
+  margin-left: 8px;
+  padding: 2px 8px;
+  font-size: 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(85, 170, 255, 0.5);
+  color: #9ccaff;
+  background: rgba(85, 170, 255, 0.12);
+  white-space: nowrap;
+}
+
+.sidebar .nav-bottom {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .nav-link:hover,
@@ -245,6 +296,10 @@ a:focus {
   background: var(--color-nav-active-bg);
   border: 1px solid var(--color-nav-active-border);
   color: var(--color-nav-active-text);
+}
+
+.nav-link .badge-pro {
+  margin-left: auto;
 }
 
 .app-main {
@@ -291,11 +346,29 @@ textarea {
   background: #15803d;
 }
 
+.btn--primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
 .btn.ghost {
   background: var(--color-app-bg-muted);
 }
 
 .btn.ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.btn--ghost {
+  background: var(--color-app-bg-muted);
+}
+
+.btn--ghost:hover:not(:disabled) {
   background: rgba(148, 163, 184, 0.2);
 }
 
@@ -400,9 +473,9 @@ textarea {
     top: 0;
     inset: auto;
     width: auto;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
     gap: 16px;
     padding: 16px;
     border-right: none;
@@ -410,13 +483,33 @@ textarea {
   }
 
   .nav {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .nav-list {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 8px;
   }
 
+  .nav-divider {
+    display: none;
+  }
+
   .nav-link {
     padding: 0.5rem 0.75rem;
+    min-width: max(140px, 45%);
+  }
+
+  .sidebar .nav-bottom {
+    margin-top: 0;
+    padding-top: 8px;
+    border-top: 1px solid var(--color-nav-border);
+  }
+
+  .nav-bottom .nav-link {
+    min-width: 100%;
   }
 
   .app-main {
@@ -430,6 +523,22 @@ textarea {
 
   .map {
     height: 56vh;
+  }
+}
+
+@media (max-width: 600px) {
+  .nav-link {
+    min-width: 100%;
+  }
+}
+
+@media (max-width: 390px) {
+  .nav-link .badge-pro {
+    margin-left: 0;
+    margin-top: 4px;
+    width: 100%;
+    text-align: center;
+    white-space: normal;
   }
 }
 
@@ -527,6 +636,224 @@ textarea {
 .card p {
   margin: 0;
   color: var(--color-muted);
+}
+
+.card.hero,
+.hero {
+  gap: var(--space-3);
+  padding: clamp(var(--space-5), 2vw + 1.5rem, var(--space-7));
+}
+
+.hero h2 {
+  margin: 0;
+  font-size: clamp(2.1rem, 2.4vw + 1.3rem, 3rem);
+  font-weight: 700;
+  color: var(--color-heading);
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--color-muted);
+  max-width: 60ch;
+}
+
+.stack {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.section-grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.section-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.panel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.panel-list__item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+}
+
+.panel-list__title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-heading);
+}
+
+.panel-list__meta {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.panel-list__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.status-pill--online {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: #4ade80;
+}
+
+.status-pill--offline {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: #fca5a5;
+}
+
+.status-pill--manual {
+  background: rgba(96, 165, 250, 0.12);
+  border-color: rgba(96, 165, 250, 0.35);
+  color: #93c5fd;
+}
+
+.device-sources {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.device-source__info {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.device-source__name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-heading);
+}
+
+.device-source__meta {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.button-row--end {
+  justify-content: flex-end;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form-field span {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.form-field .input {
+  width: 100%;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 500;
+}
+
+.toggle input {
+  width: auto;
+}
+
+.simple-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.simple-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--color-muted);
+}
+
+.simple-list li::before {
+  content: '•';
+  color: var(--color-primary);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip-row .chip {
+  flex: 0 1 auto;
+}
+
+.calibration-grid {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+@media (max-width: 640px) {
+  .panel-list__item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel-list__actions {
+    margin-left: 0;
+    justify-content: flex-start;
+  }
 }
 
 .health-dashboard {


### PR DESCRIPTION
## Summary
- refresh the sidebar to list Device, Doctor (Pro), Reports, Programs (Pro), Emergency, and a bottom-pinned Settings link with emoji icons
- add shared styling utilities plus hero card layouts and placeholder content for the new Device, Doctor, Reports, Programs, Emergency, and Settings pages
- introduce a shared app state flag, modal styles, and gating logic so Doctor and Programs prompt non-Pro accounts before access

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e80eae4a8c83328a9310c64412df3a